### PR TITLE
fix: 動画生成・ニュースフィルタ・Drive アップロードの全面修正（問題1〜5）

### DIFF
--- a/.github/workflows/keiba_news.yml
+++ b/.github/workflows/keiba_news.yml
@@ -66,13 +66,13 @@ jobs:
         if: steps.check_news.outputs.has_news == 'true'
         run: python scripts/generate_video.py
 
-      - name: Upload to YouTube
+      - name: Upload to Google Drive
         if: steps.check_news.outputs.has_news == 'true'
         env:
-          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
-          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
-          YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
-        run: python scripts/upload_youtube.py
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+        run: python scripts/upload_drive.py
 
       - name: Commit and push posted_ids.txt
         if: steps.check_news.outputs.has_news == 'true'

--- a/get_token.py
+++ b/get_token.py
@@ -30,7 +30,10 @@ CLIENT_ID = "704753208448-rfq5pkn7vtvqmthksdp58u15f4dirfbd.apps.googleuserconten
 CLIENT_SECRET = "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"
 # ========================================================
 
-SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
+SCOPES = [
+    "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/drive.file",
+]
 REDIRECT_URI = "http://localhost:8080"
 
 
@@ -63,9 +66,9 @@ def main() -> None:
     print("\n" + "=" * 60)
     print("認証成功！以下の値を GitHub Secrets に登録してください。")
     print("=" * 60)
-    print(f"\nYOUTUBE_CLIENT_ID:\n  {CLIENT_ID}")
-    print(f"\nYOUTUBE_CLIENT_SECRET:\n  {CLIENT_SECRET}")
-    print(f"\nYOUTUBE_REFRESH_TOKEN:\n  {creds.refresh_token}")
+    print(f"\nGOOGLE_CLIENT_ID:\n  {CLIENT_ID}")
+    print(f"\nGOOGLE_CLIENT_SECRET:\n  {CLIENT_SECRET}")
+    print(f"\nGOOGLE_REFRESH_TOKEN:\n  {creds.refresh_token}")
     print("\n" + "=" * 60)
 
     # オプション: トークン情報をファイルに保存
@@ -74,7 +77,7 @@ def main() -> None:
         "client_secret": CLIENT_SECRET,
         "refresh_token": creds.refresh_token,
     }
-    output_path = Path("youtube_token.json")
+    output_path = Path("google_token.json")
     output_path.write_text(json.dumps(token_info, indent=2), encoding="utf-8")
     print(f"\n（参考用に {output_path} にも保存しました。このファイルは .gitignore に追加してください）")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,5 @@ google-api-python-client==2.151.0
 google-auth==2.35.0
 google-auth-oauthlib==1.2.1
 requests==2.32.3
-moviepy
-imageio
-imageio-ffmpeg
 Pillow
 mutagen

--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -45,6 +45,31 @@ NS = {
     "content": "http://purl.org/rss/1.0/modules/content/",
 }
 
+# ---------------------------------------------------------------------------
+# 競馬関連フィルタ
+# ---------------------------------------------------------------------------
+
+_ALLOW_KEYWORDS = [
+    "競馬", "horse racing", "jra", "地方競馬", "騎手", "調教師",
+    "レース", "厩舎", "g1", "重賞", "競走馬", "牡馬", "牝馬", "騸馬",
+]
+_DENY_KEYWORDS = [
+    "ボートレース", "競艇", "オートレース", "競輪", "パチンコ", "スロット",
+]
+
+
+def is_keiba_related(entry: dict) -> bool:
+    """競馬関連の記事かどうかを判定する。除外キーワード優先。"""
+    text = (entry.get("title", "") + " " + entry.get("summary", "")).lower()
+    for kw in _DENY_KEYWORDS:
+        if kw in text:
+            return False
+    for kw in _ALLOW_KEYWORDS:
+        if kw in text:
+            return True
+    # RSSフィード自体が競馬クエリなので、どのキーワードにも引っかからない場合も通過させる
+    return True
+
 
 # ---------------------------------------------------------------------------
 # ユーティリティ
@@ -302,6 +327,10 @@ def fetch_news() -> list[dict]:
     # 投稿済みを除外
     unposted = [e for e in unique if e["id"] not in posted_ids]
     print(f"未投稿エントリー: {len(unposted)} 件")
+
+    # 競馬関連フィルタ（除外キーワードを含む記事を除去）
+    unposted = [e for e in unposted if is_keiba_related(e)]
+    print(f"競馬関連フィルタ後: {len(unposted)} 件")
 
     # 時間フィルタ: 24時間 → 48時間 → 最新3件（条件なし）
     selected: list[dict] = []

--- a/scripts/generate_video.py
+++ b/scripts/generate_video.py
@@ -1,21 +1,26 @@
 #!/usr/bin/env python3
 """
-script_N.txt を複数カットの字幕動画に変換する。
+script_N.txt を複数カットの字幕動画に変換する（ffmpeg直接方式）。
 - 縦型 1080x1920
 - 句点「。」で分割して各セリフを1カット化
-- カット長さ = 音声総尺 ÷ セリフ数（音声と同期）
-- Wikimedia Commons の競馬画像（最大5枚）をローテーション / 失敗時はグラデーション背景
-- Pillow で字幕合成（最大幅972px・1行17文字）→ moviepy で結合 → audio_N.mp3 を合成
-- moviepy 1.x / 2.x 両対応
+- カット長さ = 音声総尺 ÷ セリフ数（mutagenで厳密に取得）
+- assetsフォルダの画像をローテーション（失敗時はグラデーション背景）
+- 背景に半透明黒オーバーレイを重ねて字幕を読みやすく
+- 字幕Y座標は画面の65%（1248px）に配置
+- Pillowでフレーム画像を tmp/ に保存 → ffmpegで各クリップ生成 → concat → 音声結合
+- moviepy / imageio / imageio-ffmpeg は使わない
 """
 
 import glob
 import json
 import os
+import re
+import shutil
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
-import numpy as np
 import requests
 from PIL import Image, ImageDraw, ImageFont
 
@@ -31,8 +36,10 @@ FPS = 30
 
 FONT_SIZE_SUBTITLE = 55
 FONT_SIZE_TITLE = 30
-# 動画幅の90%（972px）÷ フォントサイズ55px ≒ 17文字
 MAX_CHARS_PER_LINE = 17
+
+# 字幕Y座標（画面の65% = 1248px）
+SUBTITLE_Y = int(VIDEO_HEIGHT * 0.65)
 
 # Wikimedia Commons 競馬関連画像（パブリックドメイン）
 HORSE_IMAGE_URLS = [
@@ -42,6 +49,7 @@ HORSE_IMAGE_URLS = [
     "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Horses_racing_at_Hyderabad.jpg/1280px-Horses_racing_at_Hyderabad.jpg",
     "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Horse_racing_Aqueduct.jpg/1280px-Horse_racing_Aqueduct.jpg",
 ]
+
 
 # ---------------------------------------------------------------------------
 # フォント検索
@@ -70,30 +78,25 @@ def find_japanese_font() -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# 画像ダウンロード（Wikimedia Commons）
+# 画像ダウンロード
 # ---------------------------------------------------------------------------
 
 def download_horse_images() -> list[str]:
-    """Wikimedia Commons から競馬画像をダウンロードし、成功したパスのリストを返す。
-    assets/ にキャッシュ済みの場合はスキップする。
-    """
+    """Wikimedia Commons から競馬画像をダウンロードし、成功したパスのリストを返す。"""
     Path(ASSETS_DIR).mkdir(exist_ok=True)
     available: list[str] = []
-
     headers = {
         "User-Agent": (
             "Mozilla/5.0 (compatible; keiba-auto-youtube/1.0; "
             "https://github.com/penmawashi8-ux/keiba-auto-youtube)"
         )
     }
-
     for i, url in enumerate(HORSE_IMAGE_URLS):
         dest = Path(ASSETS_DIR) / f"horse_{i}.jpg"
         if dest.exists() and dest.stat().st_size > 10_000:
             available.append(str(dest))
             print(f"  [キャッシュ] {dest.name}")
             continue
-
         try:
             resp = requests.get(url, headers=headers, timeout=30)
             if resp.status_code == 200 and len(resp.content) > 10_000:
@@ -104,7 +107,6 @@ def download_horse_images() -> list[str]:
                 print(f"  [スキップ] horse_{i}.jpg: HTTP {resp.status_code}", file=sys.stderr)
         except Exception as e:
             print(f"  [警告] horse_{i}.jpg ダウンロード失敗: {e}", file=sys.stderr)
-
     return available
 
 
@@ -113,24 +115,21 @@ def download_horse_images() -> list[str]:
 # ---------------------------------------------------------------------------
 
 def get_audio_duration(audio_path: str) -> float:
-    """mutagenでMP3の総再生時間（秒）を取得する。"""
+    """mutagenでMP3の総再生時間（秒）を取得する。ffmpegでフォールバック。"""
     try:
         from mutagen.mp3 import MP3
         return MP3(audio_path).info.length
     except Exception as e:
         print(f"  [警告] mutagen失敗、ffmpegで代替: {e}", file=sys.stderr)
-    # fallback: ffmpeg
-    import subprocess
     result = subprocess.run(
         ["ffmpeg", "-i", audio_path],
         capture_output=True, text=True,
     )
-    import re
     m = re.search(r"Duration:\s*(\d+):(\d+):([\d.]+)", result.stderr)
     if m:
-        h, m_, s = int(m.group(1)), int(m.group(2)), float(m.group(3))
-        return h * 3600 + m_ * 60 + s
-    return 10.0  # ultimate fallback
+        h, mi, s = int(m.group(1)), int(m.group(2)), float(m.group(3))
+        return h * 3600 + mi * 60 + s
+    return 10.0
 
 
 # ---------------------------------------------------------------------------
@@ -156,17 +155,14 @@ def load_and_resize_image(path: str) -> Image.Image:
         img = Image.open(path).convert("RGB")
     except Exception:
         return make_gradient_image()
-
     target_ratio = VIDEO_WIDTH / VIDEO_HEIGHT
     src_ratio = img.width / img.height
-
     if src_ratio > target_ratio:
         new_h = VIDEO_HEIGHT
         new_w = int(new_h * src_ratio)
     else:
         new_w = VIDEO_WIDTH
         new_h = int(new_w / src_ratio)
-
     img = img.resize((new_w, new_h), Image.LANCZOS)
     left = (new_w - VIDEO_WIDTH) // 2
     top = (new_h - VIDEO_HEIGHT) // 2
@@ -174,14 +170,14 @@ def load_and_resize_image(path: str) -> Image.Image:
 
 
 def wrap_text(text: str, max_chars: int) -> str:
-    """テキストを max_chars 文字ごとに折り返す。"""
+    """テキストを max_chars 文字ごとに折り返す（最大3行）。"""
     lines = []
     while len(text) > max_chars:
         lines.append(text[:max_chars])
         text = text[max_chars:]
     if text:
         lines.append(text)
-    return "\n".join(lines)
+    return "\n".join(lines[:3])  # 最大3行
 
 
 def add_subtitle_to_image(
@@ -190,10 +186,14 @@ def add_subtitle_to_image(
     title: str,
     font_path: str | None,
 ) -> Image.Image:
-    """背景画像にタイトル（上部）と字幕（下部）を合成し RGB 画像を返す。
-    字幕の最大横幅は動画幅の90%（972px）に制限する。
+    """背景画像にオーバーレイ・タイトル・字幕を合成して RGB 画像を返す。
+    字幕Y座標は画面の65%（1248px）。
     """
     img_rgba = bg.convert("RGBA")
+
+    # 半透明の黒オーバーレイ（全面）
+    overlay_full = Image.new("RGBA", img_rgba.size, (0, 0, 0, 120))
+    img_rgba = Image.alpha_composite(img_rgba, overlay_full)
 
     def load_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
         if font_path:
@@ -207,8 +207,8 @@ def add_subtitle_to_image(
     font_ttl = load_font(FONT_SIZE_TITLE)
 
     # ---- タイトル（上部・半透明背景）----
-    overlay = Image.new("RGBA", img_rgba.size, (0, 0, 0, 0))
-    odraw = ImageDraw.Draw(overlay)
+    title_overlay = Image.new("RGBA", img_rgba.size, (0, 0, 0, 0))
+    odraw = ImageDraw.Draw(title_overlay)
     title_short = title[:40]
     try:
         ttl_bbox = odraw.textbbox((0, 0), title_short, font=font_ttl)
@@ -223,13 +223,12 @@ def add_subtitle_to_image(
         [ttl_x - pad, ttl_y - pad, ttl_x + ttl_w + pad, ttl_y + ttl_h + pad],
         fill=(0, 0, 0, 180),
     )
-    img_rgba = Image.alpha_composite(img_rgba, overlay)
+    img_rgba = Image.alpha_composite(img_rgba, title_overlay)
 
     draw = ImageDraw.Draw(img_rgba)
     draw.text((ttl_x, ttl_y), title_short, font=font_ttl, fill=(255, 255, 255, 255))
 
-    # ---- 字幕（下部・縁取り付き）----
-    # 1行17文字で折り返し（動画幅90%=972px 相当）
+    # ---- 字幕（画面65%の位置・縁取り付き）----
     wrapped = wrap_text(subtitle, MAX_CHARS_PER_LINE)
 
     try:
@@ -241,18 +240,14 @@ def add_subtitle_to_image(
             lines = wrapped.split("\n")
             sub_bbox = (
                 0, 0,
-                max(len(l) for l in lines) * FONT_SIZE_SUBTITLE,
+                max(len(ln) for ln in lines) * FONT_SIZE_SUBTITLE,
                 len(lines) * FONT_SIZE_SUBTITLE,
             )
 
     sub_w = sub_bbox[2] - sub_bbox[0]
-    sub_h = sub_bbox[3] - sub_bbox[1]
-
-    # 最大幅 972px（動画幅90%）を超えないようにクランプ
     max_sub_w = int(VIDEO_WIDTH * 0.9)
     sub_x = max((VIDEO_WIDTH - min(sub_w, max_sub_w)) // 2, 0)
-    # 字幕エリアは画面下部20%以内（上限 VIDEO_HEIGHT * 0.80）
-    sub_y = max(VIDEO_HEIGHT - sub_h - 120, int(VIDEO_HEIGHT * 0.80))
+    sub_y = SUBTITLE_Y  # 1248px（画面の65%）
 
     # 縁取り（黒・4px）
     outline = 4
@@ -266,7 +261,10 @@ def add_subtitle_to_image(
                     font=font_sub, fill=(0, 0, 0, 255), align="center",
                 )
             except TypeError:
-                draw.text((sub_x + dx, sub_y + dy), wrapped, font=font_sub, fill=(0, 0, 0, 255))
+                draw.text(
+                    (sub_x + dx, sub_y + dy), wrapped,
+                    font=font_sub, fill=(0, 0, 0, 255),
+                )
 
     try:
         draw.multiline_text(
@@ -280,54 +278,75 @@ def add_subtitle_to_image(
 
 
 # ---------------------------------------------------------------------------
-# moviepy 動画生成（1.x / 2.x 両対応）
+# ffmpeg 動画生成
 # ---------------------------------------------------------------------------
 
-def _get_moviepy_major() -> int:
-    try:
-        import moviepy
-        ver = getattr(moviepy, "__version__", "1.0.0")
-        return int(ver.split(".")[0])
-    except Exception:
-        return 1
+def _run_ffmpeg(cmd: list[str], label: str) -> None:
+    """ffmpegコマンドを実行し、失敗時はエラーを出力して終了する。"""
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"[エラー] ffmpeg失敗 ({label}):", file=sys.stderr)
+        # 最後の300文字だけ表示
+        print(result.stderr[-300:], file=sys.stderr)
+        sys.exit(1)
 
 
-def generate_video_moviepy(
-    cuts: list[tuple[np.ndarray, float]],
+def generate_video_ffmpeg(
+    frames: list[tuple[str, float]],
     audio_path: str,
     output_path: str,
+    tmp_dir: str,
 ) -> None:
-    """カットリスト（numpy配列, 秒数）と音声から動画を生成する。"""
-    major = _get_moviepy_major()
-    print(f"  moviepy {major}.x を使用")
+    """各フレームJPEGをffmpegでクリップ化 → concat → 音声結合して動画を生成する。"""
+    clip_paths = []
+    for i, (frame_path, duration) in enumerate(frames):
+        clip_path = os.path.join(tmp_dir, f"clip_{i:04d}.mp4")
+        _run_ffmpeg([
+            "ffmpeg", "-y",
+            "-loop", "1",
+            "-framerate", str(FPS),
+            "-i", frame_path,
+            "-t", f"{duration:.6f}",
+            "-vf", f"scale={VIDEO_WIDTH}:{VIDEO_HEIGHT}",
+            "-c:v", "libx264",
+            "-preset", "fast",
+            "-crf", "23",
+            "-pix_fmt", "yuv420p",
+            "-an",
+            clip_path,
+        ], f"clip_{i:04d}")
+        clip_paths.append(clip_path)
+        print(f"  クリップ {i + 1}/{len(frames)} 生成 ({duration:.2f}秒)")
 
-    if major >= 2:
-        from moviepy import AudioFileClip, ImageClip, concatenate_videoclips
+    # concat リストファイル（絶対パスで記述）
+    concat_list = os.path.join(tmp_dir, "concat.txt")
+    with open(concat_list, "w", encoding="utf-8") as f:
+        for cp in clip_paths:
+            f.write(f"file '{os.path.abspath(cp)}'\n")
 
-        clips = [ImageClip(frame).with_duration(dur) for frame, dur in cuts]
-        video = concatenate_videoclips(clips)
-        audio = AudioFileClip(audio_path)
-        final_dur = min(video.duration, audio.duration)
-        video = video.with_duration(final_dur)
-        video = video.with_audio(audio.with_duration(final_dur))
-    else:
-        from moviepy.editor import AudioFileClip, ImageClip, concatenate_videoclips
+    # 全クリップを結合（再エンコードなしで高速）
+    merged_video = os.path.join(tmp_dir, "merged.mp4")
+    _run_ffmpeg([
+        "ffmpeg", "-y",
+        "-f", "concat",
+        "-safe", "0",
+        "-i", concat_list,
+        "-c", "copy",
+        merged_video,
+    ], "concat")
 
-        clips = [ImageClip(frame).set_duration(dur) for frame, dur in cuts]
-        video = concatenate_videoclips(clips)
-        audio = AudioFileClip(audio_path)
-        final_dur = min(video.duration, audio.duration)
-        video = video.subclip(0, final_dur)
-        video = video.set_audio(audio.subclip(0, final_dur))
-
-    video.write_videofile(
+    # 音声を結合して最終動画を出力
+    _run_ffmpeg([
+        "ffmpeg", "-y",
+        "-i", merged_video,
+        "-i", audio_path,
+        "-c:v", "copy",
+        "-c:a", "aac",
+        "-shortest",
+        "-movflags", "+faststart",
         output_path,
-        fps=FPS,
-        codec="libx264",
-        audio_codec="aac",
-        preset="fast",
-        ffmpeg_params=["-crf", "23", "-movflags", "+faststart"],
-    )
+    ], "audio-merge")
+
     size_mb = Path(output_path).stat().st_size / (1024 * 1024)
     print(f"  → {output_path} ({size_mb:.1f} MB)")
 
@@ -337,7 +356,7 @@ def generate_video_moviepy(
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    print("=== 動画生成開始（マルチカット版）===")
+    print("=== 動画生成開始（ffmpeg直接方式）===")
 
     news_items: list[dict] = json.loads(Path(NEWS_JSON).read_text(encoding="utf-8"))
     if not news_items:
@@ -346,18 +365,15 @@ def main() -> None:
 
     Path(OUTPUT_DIR).mkdir(exist_ok=True)
 
-    # 競馬画像をダウンロード（Wikimedia Commons）
     print("競馬関連画像をダウンロード中...")
     available_images = download_horse_images()
     print(f"  取得画像: {len(available_images)} 枚")
     if not available_images:
         print("  → 画像なし。グラデーション背景を使用します。")
 
-    # 日本語フォントを検索
     font_path = find_japanese_font()
     print(f"  日本語フォント: {font_path or '見つからず（デフォルト使用）'}")
 
-    # script_N.txt を処理
     script_files = sorted(Path(OUTPUT_DIR).glob("script_*.txt"))
     if not script_files:
         print(f"[エラー] {OUTPUT_DIR}/script_*.txt が見つかりません。", file=sys.stderr)
@@ -377,39 +393,48 @@ def main() -> None:
 
         print(f"\n--- 動画生成 [{idx}]: {title[:50]} ---")
 
-        # 音声総尺を取得
         audio_duration = get_audio_duration(audio_path)
         print(f"  音声長: {audio_duration:.1f}秒")
 
-        # 脚本を句点で分割
         script = script_file.read_text(encoding="utf-8").strip()
         raw_sentences = [s.strip() for s in script.split("。") if s.strip()]
         sentences = [s + "。" for s in raw_sentences]
-
         print(f"  セリフ数: {len(sentences)}")
 
+        if not sentences:
+            print("  [警告] セリフが空です。スキップします。")
+            continue
+
         # 1カットあたりの表示時間 = 音声総尺 ÷ セリフ数
-        cut_duration = audio_duration / len(sentences) if sentences else audio_duration
+        cut_duration = audio_duration / len(sentences)
         print(f"  1カット: {cut_duration:.2f}秒")
 
-        # カット生成
-        cuts: list[tuple[np.ndarray, float]] = []
-        for i, sentence in enumerate(sentences):
-            if available_images:
-                bg = load_and_resize_image(available_images[i % len(available_images)])
-            else:
-                bg = make_gradient_image()
+        tmp_dir = tempfile.mkdtemp(prefix="keiba_video_")
+        try:
+            frames: list[tuple[str, float]] = []
+            for i, sentence in enumerate(sentences):
+                if available_images:
+                    bg = load_and_resize_image(available_images[i % len(available_images)])
+                else:
+                    bg = make_gradient_image()
 
-            frame_img = add_subtitle_to_image(bg, sentence, title, font_path)
-            cuts.append((np.array(frame_img), cut_duration))
+                frame_img = add_subtitle_to_image(bg, sentence, title, font_path)
+                frame_path = os.path.join(tmp_dir, f"frame_{i:04d}.jpg")
+                frame_img.save(frame_path, "JPEG", quality=95)
+                frames.append((frame_path, cut_duration))
 
-            preview = sentence[:20].replace("\n", " ")
-            print(f"  カット {i + 1}/{len(sentences)}: 「{preview}…」({cut_duration:.2f}秒)")
+                preview = sentence[:20].replace("\n", " ")
+                print(f"  フレーム {i + 1}/{len(sentences)}: 「{preview}…」")
 
-        # moviepy で動画生成
-        generate_video_moviepy(cuts, audio_path, output_path)
+            generate_video_ffmpeg(frames, audio_path, output_path, tmp_dir)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            print("  一時フォルダを削除しました。")
 
-    video_files = sorted(Path(OUTPUT_DIR).glob("video_*.mp4"))
+    video_files = sorted(
+        f for f in Path(OUTPUT_DIR).glob("video_*.mp4")
+        if f.stem.split("_")[1].isdigit()
+    )
     print(f"\n{len(video_files)} 本の動画を生成しました。")
 
 

--- a/scripts/upload_drive.py
+++ b/scripts/upload_drive.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Google Drive APIを使ってoutput/video_*.mp4をアップロードする（テスト用）。
+- OAuth2（refresh_token方式）で認証
+- アップロード後、「リンクを知っている全員が閲覧可能」に設定
+- 共有リンクをコンソールに出力する
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import google.auth.transport.requests
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaFileUpload
+
+NEWS_JSON = "news.json"
+OUTPUT_DIR = "output"
+POSTED_IDS_FILE = "posted_ids.txt"
+
+DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+
+
+def load_credentials() -> Credentials:
+    """環境変数からOAuth2認証情報を構築する。"""
+    client_id = os.environ.get("GOOGLE_CLIENT_ID")
+    client_secret = os.environ.get("GOOGLE_CLIENT_SECRET")
+    refresh_token = os.environ.get("GOOGLE_REFRESH_TOKEN")
+
+    missing = [
+        name for name, val in [
+            ("GOOGLE_CLIENT_ID", client_id),
+            ("GOOGLE_CLIENT_SECRET", client_secret),
+            ("GOOGLE_REFRESH_TOKEN", refresh_token),
+        ] if not val
+    ]
+    if missing:
+        print(f"[エラー] 環境変数が未設定です: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+
+    creds = Credentials(
+        token=None,
+        refresh_token=refresh_token,
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id=client_id,
+        client_secret=client_secret,
+        scopes=DRIVE_SCOPES,
+    )
+
+    try:
+        request = google.auth.transport.requests.Request()
+        creds.refresh(request)
+        print("OAuth2トークンのリフレッシュ成功。")
+    except Exception as e:
+        print(f"[エラー] トークンリフレッシュ失敗: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return creds
+
+
+def update_posted_ids(news_items: list[dict]) -> None:
+    """投稿済みIDをposted_ids.txtに追記する。"""
+    path = Path(POSTED_IDS_FILE)
+    existing = set(path.read_text(encoding="utf-8").splitlines()) if path.exists() else set()
+    new_ids = {item["id"] for item in news_items}
+    all_ids = existing | new_ids
+    path.write_text("\n".join(sorted(all_ids)), encoding="utf-8")
+    print(f"投稿済みID {len(new_ids)} 件を {POSTED_IDS_FILE} に追記しました。")
+
+
+def upload_to_drive(drive, title: str, video_path: str) -> str:
+    """Google Drive に動画をアップロードして共有リンクを返す。"""
+    file_metadata = {
+        "name": f"【競馬速報】{title}.mp4",
+        "mimeType": "video/mp4",
+    }
+    media = MediaFileUpload(
+        video_path,
+        mimetype="video/mp4",
+        resumable=True,
+        chunksize=1024 * 1024,
+    )
+
+    print(f"Google Drive にアップロード中: {file_metadata['name']}")
+    try:
+        request = drive.files().create(
+            body=file_metadata,
+            media_body=media,
+            fields="id",
+        )
+
+        response = None
+        while response is None:
+            status, response = request.next_chunk()
+            if status:
+                progress = int(status.progress() * 100)
+                print(f"  アップロード進捗: {progress}%")
+
+        file_id = response["id"]
+        print(f"アップロード完了！ File ID: {file_id}")
+
+        # 「リンクを知っている全員が閲覧可能」に設定
+        drive.permissions().create(
+            fileId=file_id,
+            body={"type": "anyone", "role": "reader"},
+        ).execute()
+
+        share_link = f"https://drive.google.com/file/d/{file_id}/view"
+        return share_link
+
+    except HttpError as e:
+        try:
+            error_content = json.loads(e.content.decode("utf-8"))
+        except Exception:
+            error_content = {}
+        print(f"[エラー] Drive API HTTP {e.resp.status}: {error_content}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"[エラー] アップロード失敗: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    print("=== Google Drive アップロード開始 ===")
+
+    if not Path(NEWS_JSON).exists():
+        print(f"[エラー] {NEWS_JSON} が見つかりません。", file=sys.stderr)
+        sys.exit(1)
+
+    news_items: list[dict] = json.loads(Path(NEWS_JSON).read_text(encoding="utf-8"))
+    if not news_items:
+        print("ニュースが0件のためアップロードをスキップします。")
+        sys.exit(0)
+
+    # video_[数字].mp4 のみ対象（一時ファイルを除外）
+    video_files = sorted(
+        f for f in Path(OUTPUT_DIR).glob("video_*.mp4")
+        if f.stem.split("_")[1].isdigit()
+    )
+    if not video_files:
+        print(f"[エラー] {OUTPUT_DIR}/video_*.mp4 が見つかりません。", file=sys.stderr)
+        sys.exit(1)
+
+    creds = load_credentials()
+    drive = build("drive", "v3", credentials=creds)
+
+    uploaded_links: list[str] = []
+    for video_file in video_files:
+        idx = int(video_file.stem.split("_")[1])
+
+        if idx >= len(news_items):
+            print(f"  [警告] インデックス {idx} の記事がありません。スキップします。")
+            continue
+
+        item = news_items[idx]
+        title = item["title"]
+
+        print(f"\n--- アップロード [{idx}]: {title[:50]} ---")
+        share_link = upload_to_drive(drive, title, str(video_file))
+        uploaded_links.append(share_link)
+        print(f"動画リンク: {share_link}")
+
+    update_posted_ids(news_items)
+
+    print(f"\n=== アップロード完了: {len(uploaded_links)} 本 ===")
+    for link in uploaded_links:
+        print(f"  {link}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 修正内容

### 問題1・3・4: generate_video.py を ffmpeg 直接方式に書き直し
- moviepy / imageio / imageio-ffmpeg を**完全廃止**、ffmpegコマンドを直接呼び出し
- Pillowで各カットのJPEGフレームを一時フォルダに生成
- ffmpeg `-loop 1 -t {秒}` で静止画→クリップ変換（秒数厳密指定）
- ffmpeg concat で全クリップ結合 → audio.mp3 を結合
- **mutagenで音声総尺を取得**して `総尺 ÷ セリフ数 = 1カット秒数` で完全同期
- 字幕Y座標を画面**65%（1248px）** に変更（65〜85%の範囲内に収まる）
- 背景画像に**半透明黒オーバーレイ（alpha=120）** を全面に追加して字幕可読性向上

### 問題2: fetch_news.py に競馬関連フィルタを追加
- **除外**: ボートレース・競艇・オートレース・競輪・パチンコ・スロット
- **許可**: 競馬・JRA・騎手・調教師・重賞・G1 など

### 問題5: Google Drive アップロードに切り替え（テスト用）
- `upload_drive.py` を新規作成（Drive API + OAuth2 refresh_token方式）
- アップロード後に「リンクを知っている全員が閲覧可能」設定
- 共有リンクを `動画リンク: https://...` 形式でログ出力
- `keiba_news.yml`: `upload_youtube.py` → `upload_drive.py` に変更
- 環境変数を `YOUTUBE_*` → `GOOGLE_*` に変更
- `get_token.py`: `drive.file` スコープを追加
- `requirements.txt`: moviepy / imageio / imageio-ffmpeg を削除

---

## ⚠️ 手動対応が必要: GOOGLE_REFRESH_TOKEN

`GOOGLE_CLIENT_ID` と `GOOGLE_CLIENT_SECRET` は自動で GitHub Secrets に登録済みです。

`GOOGLE_REFRESH_TOKEN` は **Drive スコープを含む新しいトークンが必要** です。以下の手順で取得してください：

```bash
python get_token.py
```

表示された `GOOGLE_REFRESH_TOKEN` の値を GitHub Settings → Secrets → Actions に登録してください。

https://claude.ai/code/session_017dxpWMsXeynxbfksnevBW5