### PR TITLE
fix: youtube.force-sslスコープを分離しサムネイル403を警告のみに修正

### DIFF
--- a/scripts/get_refresh_token.py
+++ b/scripts/get_refresh_token.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+YouTube サムネイル対応リフレッシュトークン取得スクリプト。
+
+使い方:
+  1. Google Cloud Console でリダイレクトURIに http://localhost:8080/ を追加
+  2. GOOGLE_CLIENT_ID と GOOGLE_CLIENT_SECRET を環境変数にセット
+  3. このスクリプトを実行してブラウザで認証
+  4. 表示された refresh_token を GitHub Secrets の GOOGLE_REFRESH_TOKEN に上書き
+
+必要スコープ:
+  - youtube.upload     : 動画アップロード
+  - youtube.force-ssl  : サムネイルアップロード
+"""
+
+import os
+import sys
+import urllib.parse
+import urllib.request
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
+CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET", "")
+REDIRECT_URI = "http://localhost:8080/"
+SCOPES = [
+    "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/youtube.force-ssl",
+]
+
+AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+
+def main():
+    if not CLIENT_ID or not CLIENT_SECRET:
+        print("[エラー] GOOGLE_CLIENT_ID と GOOGLE_CLIENT_SECRET を環境変数にセットしてください。")
+        sys.exit(1)
+
+    params = {
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "access_type": "offline",
+        "prompt": "consent",  # 必ず refresh_token を返させる
+    }
+    url = AUTH_URL + "?" + urllib.parse.urlencode(params)
+    print("以下のURLをブラウザで開いて認証してください:\n")
+    print(url)
+    print()
+
+    # ローカルサーバーで認証コードを受け取る
+    auth_code = None
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            nonlocal auth_code
+            query = urllib.parse.urlparse(self.path).query
+            params = urllib.parse.parse_qs(query)
+            auth_code = params.get("code", [None])[0]
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"<h1>OK: ターミナルに戻ってください</h1>")
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("localhost", 8080), Handler)
+    print("http://localhost:8080/ で待機中... (ブラウザで認証後に自動で進みます)\n")
+    server.handle_request()
+
+    if not auth_code:
+        print("[エラー] 認証コードを取得できませんでした。")
+        sys.exit(1)
+
+    # 認証コードをトークンに交換
+    data = urllib.parse.urlencode({
+        "code": auth_code,
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "redirect_uri": REDIRECT_URI,
+        "grant_type": "authorization_code",
+    }).encode()
+
+    req = urllib.request.Request(TOKEN_URL, data=data, method="POST")
+    with urllib.request.urlopen(req) as resp:
+        token_data = json.loads(resp.read())
+
+    refresh_token = token_data.get("refresh_token")
+    if not refresh_token:
+        print("[エラー] refresh_token が取得できませんでした。")
+        print(json.dumps(token_data, indent=2))
+        sys.exit(1)
+
+    print("=" * 60)
+    print("取得成功！以下の refresh_token を")
+    print("GitHub Secrets > GOOGLE_REFRESH_TOKEN に上書きしてください:\n")
+    print(refresh_token)
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload_youtube.py
+++ b/scripts/upload_youtube.py
@@ -21,10 +21,11 @@ OUTPUT_DIR = "output"
 ASSETS_DIR = "assets"
 POSTED_IDS_FILE = "posted_ids.txt"
 
-YOUTUBE_SCOPES = [
-    "https://www.googleapis.com/auth/youtube.upload",
-    "https://www.googleapis.com/auth/youtube.force-ssl",
-]
+YOUTUBE_SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
+# サムネイルAPIには youtube.force-ssl スコープが必要。
+# 既存トークンが youtube.upload のみの場合、thumbnails.set は 403 になるが
+# 動画アップロード自体には影響しない（upload_thumbnail が警告のみで継続）。
+# 再発行手順は scripts/get_refresh_token.py を参照。
 CATEGORY_ID = "17"  # スポーツ
 TAGS = ["競馬", "競馬ニュース", "keiba", "Shorts", "競馬速報"]
 


### PR DESCRIPTION
## 原因\n`youtube.force-ssl` をスコープに追加したため、既存の refresh_token（`youtube.upload` のみ）でのトークン更新が失敗。\n\n## 修正\n- `YOUTUBE_SCOPES` を `youtube.upload` のみに戻し既存トークンで動作を回復\n- サムネイル失敗（403）は警告のみ、動画アップロードは継続\n\n## サムネイルを有効化する手順（別途作業）\n`scripts/get_refresh_token.py` を手元で実行して新しい refresh_token を取得 → Secrets 更新で有効化できます。"