### PR TITLE
fix: AI画像失敗時にアクションを停止＆サムネイルをファイル保存

### DIFF
--- a/.github/workflows/keiba_news.yml
+++ b/.github/workflows/keiba_news.yml
@@ -73,7 +73,6 @@ jobs:
 
       - name: AI画像を生成
         id: ai_images
-        continue-on-error: true
         if: steps.check_news.outputs.has_news == 'true'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -159,7 +158,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add posted_ids.txt last_upload_result.txt
+          git add posted_ids.txt last_upload_result.txt output/thumbnail_*.jpg 2>/dev/null || true
           if git diff --staged --quiet; then
             echo "変更なし。コミットをスキップします。"
           else

--- a/scripts/generate_images.py
+++ b/scripts/generate_images.py
@@ -19,6 +19,8 @@ GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 
 HF_MODEL_URL = "https://router.huggingface.co/hf-inference/models/black-forest-labs/FLUX.1-schnell"
 
+JPEG_MAGIC = b"\xff\xd8\xff"
+
 DEFAULT_PROMPTS = [
     "cinematic photo of horses racing at sunset on a beautiful racecourse, dramatic lighting, high quality",
     "cinematic photo of jockey riding horse on racecourse, motion blur, high quality",
@@ -84,6 +86,13 @@ def generate_via_huggingface(hf_token: str, prompt: str, filepath: str) -> bool:
             r = requests.post(HF_MODEL_URL, headers=headers, json=payload, timeout=120)
             print(f"    [HF] status={r.status_code}", flush=True)
             if r.status_code == 200 and len(r.content) > 1000:
+                if not r.content.startswith(JPEG_MAGIC):
+                    print(
+                        f"    [エラー] HFからJPEGでないデータを受信 "
+                        f"(先頭bytes: {r.content[:16].hex()}, body: {r.content[:200]})",
+                        flush=True,
+                    )
+                    break
                 Path(filepath).write_bytes(r.content)
                 print(f"    ✅ HF成功: {filepath} ({len(r.content)//1024}KB)", flush=True)
                 return True

--- a/scripts/upload_youtube.py
+++ b/scripts/upload_youtube.py
@@ -246,6 +246,14 @@ def generate_thumbnail(title: str, idx: int) -> bytes:
     return buf.getvalue()
 
 
+def save_thumbnail(thumbnail_bytes: bytes, idx: int) -> str:
+    """サムネイル画像をファイルに保存して、パスを返す。"""
+    thumb_path = f"{OUTPUT_DIR}/thumbnail_{idx}.jpg"
+    Path(thumb_path).write_bytes(thumbnail_bytes)
+    print(f"  サムネイル保存: {thumb_path}")
+    return thumb_path
+
+
 def upload_thumbnail(youtube, video_id: str, thumbnail_bytes: bytes) -> None:
     """動画にサムネイルをアップロードする（失敗は警告のみ）。"""
     media = MediaIoBaseUpload(
@@ -264,8 +272,9 @@ def upload_thumbnail(youtube, video_id: str, thumbnail_bytes: bytes) -> None:
             reason = ""
         if e.resp.status == 403 and reason in ("forbidden", "channelNotEligible"):
             print(
-                "[警告] サムネイル設定には YouTube チャンネルの電話番号認証が必要です。\n"
-                "       YouTube Studio > 設定 > チャンネル > 機能の利用資格 で確認してください。",
+                "[警告] サムネイルAPIには YouTube チャンネルの電話番号認証が必要です。\n"
+                "       output/thumbnail_N.jpg を YouTube Studio から手動でアップロードしてください。\n"
+                "       YouTube Studio > コンテンツ > 動画を選択 > 詳細 > サムネイル",
                 file=sys.stderr,
             )
         else:
@@ -439,10 +448,11 @@ def main() -> None:
         if quota_exceeded:
             break
 
-        # サムネイル生成・アップロード
+        # サムネイル生成・保存・アップロード
         print("  サムネイル生成中...")
         try:
             thumb_bytes = generate_thumbnail(title, idx)
+            save_thumbnail(thumb_bytes, idx)
             upload_thumbnail(youtube, video_id, thumb_bytes)
         except Exception as e:
             print(f"[警告] サムネイル処理失敗: {e}", file=sys.stderr)


### PR DESCRIPTION
## 問題1: AI画像失敗時に変な模様が出る

**原因:**
- ワークフローの `continue-on-error: true` により、画像生成失敗しても処理が続行されていた
- HuggingFace が HTTP 200 でも JSON エラー等の非JPEG データを返すケースがあり、それをそのまま書き込んでいた

**修正:**
- `continue-on-error: true` を削除 → 画像生成失敗でワークフロー即停止
- JPEG マジックバイト (`\xff\xd8\xff`) 検証を追加 → 非JPEG データは書き込まずエラーログを出力

## 問題2: サムネイル設定に電話番号登録が必要

**原因:** YouTube `thumbnails.set` API は電話番号認証済みチャンネルのみ使用可能（YouTube プラットフォームの制限）

**対処:**
- 生成したサムネイルを `output/thumbnail_N.jpg` に保存してリポジトリにコミット
- Actions の artifacts またはリポジトリからダウンロードして YouTube Studio で手動アップロード可能
- エラーメッセージに手順を追記