### PR TITLE
feat: 画像生成をPollinations.ai(無料)に切り替え＋HFへのフォールバック

### DIFF
--- a/scripts/generate_images.py
+++ b/scripts/generate_images.py
@@ -1,25 +1,29 @@
 #!/usr/bin/env python3
 """
 generate_images.py - 無料で競馬AI画像を生成する。
-HuggingFace FLUX.1-schnell (HF_TOKEN が設定されている場合) を使用。
+Pollinations.ai (無料・認証不要) をメインに使用し、
+失敗時は HuggingFace FLUX.1-schnell にフォールバック（逆も同様）。
 """
 
+import io
 import json
 import os
+import random
 import sys
 import time
+import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import requests
+from PIL import Image
 
 NEWS_JSON = "news.json"
 ASSETS_DIR = Path("assets")
 GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 
+POLLINATIONS_URL = "https://image.pollinations.ai/prompt/{prompt}?width=768&height=1280&nologo=true&seed={seed}&model=flux"
 HF_MODEL_URL = "https://router.huggingface.co/hf-inference/models/black-forest-labs/FLUX.1-schnell"
-
-JPEG_MAGIC = b"\xff\xd8\xff"
 
 DEFAULT_PROMPTS = [
     "cinematic photo of horses racing at sunset on a beautiful racecourse, dramatic lighting, high quality",
@@ -59,20 +63,18 @@ def get_prompts_from_gemini(api_keys: list[str], news_items: list[dict]) -> list
             text = text.replace("```json", "").replace("```", "").strip()
             prompts = json.loads(text)
             if isinstance(prompts, list) and len(prompts) >= 4:
-                # 要素が文字列でない場合（dictなど）は文字列に変換
                 result = []
-                for item in prompts:
-                    if isinstance(item, str):
-                        result.append(item)
-                    elif isinstance(item, dict):
-                        # "prompt"/"text"/"description"などのキーを探す
-                        val = next((item[k] for k in ("prompt", "text", "description", "content") if k in item), None)
-                        if val is None and item:
-                            val = str(list(item.values())[0])
+                for it in prompts:
+                    if isinstance(it, str):
+                        result.append(it)
+                    elif isinstance(it, dict):
+                        val = next((it[k] for k in ("prompt", "text", "description", "content") if k in it), None)
+                        if val is None and it:
+                            val = str(list(it.values())[0])
                         if val:
                             result.append(str(val))
                     else:
-                        result.append(str(item))
+                        result.append(str(it))
                 if len(result) >= 4:
                     print(f"  Geminiプロンプト生成成功 (key={key_label}): {len(result)}件", flush=True)
                     return result[:4]
@@ -83,25 +85,59 @@ def get_prompts_from_gemini(api_keys: list[str], news_items: list[dict]) -> list
     return DEFAULT_PROMPTS
 
 
+def save_image_bytes(content: bytes, filepath: str) -> bool:
+    """バイト列を画像として検証しJPEGで保存する。PIL で開けない場合は False を返す。"""
+    try:
+        img = Image.open(io.BytesIO(content)).convert("RGB")
+        img.save(filepath, "JPEG", quality=92)
+        return True
+    except Exception as e:
+        print(f"    [エラー] 画像として開けません: {e}", flush=True)
+        return False
+
+
+def generate_via_pollinations(prompt: str, filepath: str) -> bool:
+    """Pollinations.ai で画像生成（無料・認証不要）"""
+    encoded = urllib.parse.quote(prompt)
+    seed = random.randint(1, 99999)
+    url = POLLINATIONS_URL.format(prompt=encoded, seed=seed)
+    for attempt in range(3):
+        try:
+            r = requests.get(url, timeout=90)
+            print(f"    [Pollinations] status={r.status_code}", flush=True)
+            if r.status_code == 200 and len(r.content) > 1000:
+                if save_image_bytes(r.content, filepath):
+                    size_kb = len(r.content) // 1024
+                    print(f"    ✅ Pollinations成功: {filepath} ({size_kb}KB)", flush=True)
+                    return True
+            elif r.status_code == 429:
+                wait = 30 * (attempt + 1)
+                print(f"    レートリミット... {wait}秒待機", flush=True)
+                time.sleep(wait)
+            else:
+                print(f"    エラー: {r.status_code} {r.text[:200]}", flush=True)
+                if attempt < 2:
+                    time.sleep(10)
+        except Exception as e:
+            print(f"    例外: {type(e).__name__}: {e}", flush=True)
+            if attempt < 2:
+                time.sleep(10)
+    return False
+
+
 def generate_via_huggingface(hf_token: str, prompt: str, filepath: str) -> bool:
     """HuggingFace Inference API (FLUX.1-schnell) で画像生成"""
     headers = {"Authorization": f"Bearer {hf_token}"}
     payload = {"inputs": prompt}
-    for attempt in range(4):
+    for attempt in range(3):
         try:
             r = requests.post(HF_MODEL_URL, headers=headers, json=payload, timeout=120)
             print(f"    [HF] status={r.status_code}", flush=True)
             if r.status_code == 200 and len(r.content) > 1000:
-                if not r.content.startswith(JPEG_MAGIC):
-                    print(
-                        f"    [エラー] HFからJPEGでないデータを受信 "
-                        f"(先頭bytes: {r.content[:16].hex()}, body: {r.content[:200]})",
-                        flush=True,
-                    )
-                    break
-                Path(filepath).write_bytes(r.content)
-                print(f"    ✅ HF成功: {filepath} ({len(r.content)//1024}KB)", flush=True)
-                return True
+                if save_image_bytes(r.content, filepath):
+                    size_kb = len(r.content) // 1024
+                    print(f"    ✅ HF成功: {filepath} ({size_kb}KB)", flush=True)
+                    return True
             elif r.status_code == 503:
                 wait = 30 * (attempt + 1)
                 print(f"    モデル読み込み中... {wait}秒待機", flush=True)
@@ -128,6 +164,7 @@ def main() -> None:
     ]
     hf_token = os.environ.get("HF_TOKEN", "")
     print(f"Gemini APIキー: {len(gemini_keys)} 件ロード", flush=True)
+    print(f"HuggingFace: {'あり' if hf_token else 'なし'}", flush=True)
 
     # プロンプト生成
     try:
@@ -140,18 +177,24 @@ def main() -> None:
     for i, p in enumerate(prompts, 1):
         print(f"    [{i}] {p[:80]}", flush=True)
 
-    # 画像生成（並列）
+    # 画像生成（並列）: Pollinations → HF の順にフォールバック
     def generate_one(args):
         i, prompt = args
         out_path = str(ASSETS_DIR / f"ai_{i}.jpg")
         print(f"\n  [{i}/4] 画像生成中...", flush=True)
 
-        # HuggingFace FLUX.1-schnell
+        # 1st: Pollinations.ai（無料・認証不要）
+        print(f"  [{i}] → Pollinations.ai を試行", flush=True)
+        if generate_via_pollinations(prompt, out_path):
+            return i, True
+
+        # 2nd: HuggingFace（トークンがある場合）
         if hf_token:
-            print(f"  [{i}] → HuggingFace FLUX.1-schnell を試行", flush=True)
+            print(f"  [{i}] → Pollinations失敗。HuggingFace にフォールバック", flush=True)
             if generate_via_huggingface(hf_token, prompt, out_path):
                 return i, True
 
+        print(f"  [{i}] → 全手段で画像生成失敗", flush=True)
         return i, False
 
     failed = []


### PR DESCRIPTION
## 変更内容

HuggingFace の月次クレジット枯渇（402エラー）対策。

**優先順位:**
1. **Pollinations.ai**（無料・認証不要・FLUX model）
2. **HuggingFace** FLUX.1-schnell（HF_TOKENがある場合のフォールバック）

どちらかが失敗したら自動的に切り替え。PIL で画像検証＆JPEG変換も実施。