### PR TITLE
feat: 画像取得をPixabay(無料実写写真)に切り替え＋HFフォールバック

### DIFF
--- a/.github/workflows/keiba_news.yml
+++ b/.github/workflows/keiba_news.yml
@@ -80,6 +80,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_API_KEY_2: ${{ secrets.GEMINI_API_KEY_2 }}
           GEMINI_API_KEY_3: ${{ secrets.GEMINI_API_KEY_3 }}
+          PIXABAY_API_KEY: ${{ secrets.PIXABAY_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -u scripts/generate_images.py 2>&1 | tee "$GITHUB_WORKSPACE/ai_images_log.txt"

--- a/scripts/generate_images.py
+++ b/scripts/generate_images.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 """
-generate_images.py - 無料で競馬AI画像を生成する。
-Pollinations.ai (無料・認証不要) をメインに使用し、
-失敗時は HuggingFace FLUX.1-schnell にフォールバック（逆も同様）。
+generate_images.py - 競馬関連画像を取得する。
+
+優先順位:
+  1. Pixabay API（無料・実写競馬写真）
+  2. HuggingFace Inference API（HF_TOKEN が設定されている場合）
+  3. どちらも失敗 → グラデーション背景（generate_video.py が自動生成）
+
+Pixabay APIキーは PIXABAY_API_KEY 環境変数にセット。
+  取得先: https://pixabay.com/api/docs/ （無料アカウント登録後に即発行可能）
 """
 
 import io
@@ -11,7 +17,6 @@ import os
 import random
 import sys
 import time
-import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -22,8 +27,16 @@ NEWS_JSON = "news.json"
 ASSETS_DIR = Path("assets")
 GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 
-POLLINATIONS_URL = "https://image.pollinations.ai/prompt/{prompt}?width=768&height=1280&seed={seed}&model=flux"
+PIXABAY_API_URL = "https://pixabay.com/api/"
 HF_MODEL_URL = "https://router.huggingface.co/hf-inference/models/black-forest-labs/FLUX.1-schnell"
+
+# 競馬関連の検索クエリ（ローテーション）
+PIXABAY_QUERIES = [
+    "horse racing",
+    "thoroughbred horse",
+    "jockey horse race",
+    "horse racing track",
+]
 
 DEFAULT_PROMPTS = [
     "cinematic photo of horses racing at sunset on a beautiful racecourse, dramatic lighting, high quality",
@@ -86,7 +99,7 @@ def get_prompts_from_gemini(api_keys: list[str], news_items: list[dict]) -> list
 
 
 def save_image_bytes(content: bytes, filepath: str) -> bool:
-    """バイト列を画像として検証しJPEGで保存する。PIL で開けない場合は False を返す。"""
+    """バイト列を画像として検証しJPEGで保存する。"""
     try:
         img = Image.open(io.BytesIO(content)).convert("RGB")
         img.save(filepath, "JPEG", quality=92)
@@ -96,32 +109,40 @@ def save_image_bytes(content: bytes, filepath: str) -> bool:
         return False
 
 
-def generate_via_pollinations(prompt: str, filepath: str) -> bool:
-    """Pollinations.ai で画像生成（無料・認証不要）"""
-    encoded = urllib.parse.quote(prompt)
-    seed = random.randint(1, 99999)
-    url = POLLINATIONS_URL.format(prompt=encoded, seed=seed)
-    for attempt in range(3):
-        try:
-            r = requests.get(url, timeout=90)
-            print(f"    [Pollinations] status={r.status_code}", flush=True)
-            if r.status_code == 200 and len(r.content) > 1000:
-                if save_image_bytes(r.content, filepath):
-                    size_kb = len(r.content) // 1024
-                    print(f"    ✅ Pollinations成功: {filepath} ({size_kb}KB)", flush=True)
-                    return True
-            elif r.status_code == 429:
-                wait = 30 * (attempt + 1)
-                print(f"    レートリミット... {wait}秒待機", flush=True)
-                time.sleep(wait)
-            else:
-                print(f"    エラー: {r.status_code} {r.text[:200]}", flush=True)
-                if attempt < 2:
-                    time.sleep(10)
-        except Exception as e:
-            print(f"    例外: {type(e).__name__}: {e}", flush=True)
-            if attempt < 2:
-                time.sleep(10)
+def generate_via_pixabay(api_key: str, query: str, filepath: str) -> bool:
+    """Pixabay API で競馬写真を取得して保存する。"""
+    params = {
+        "key": api_key,
+        "q": query,
+        "image_type": "photo",
+        "category": "animals",
+        "min_width": 640,
+        "per_page": 20,
+        "safesearch": "true",
+    }
+    try:
+        r = requests.get(PIXABAY_API_URL, params=params, timeout=30)
+        print(f"    [Pixabay] status={r.status_code} query='{query}'", flush=True)
+        if r.status_code != 200:
+            print(f"    エラー: {r.status_code} {r.text[:200]}", flush=True)
+            return False
+        hits = r.json().get("hits", [])
+        if not hits:
+            print(f"    [Pixabay] 該当画像なし: {query}", flush=True)
+            return False
+        # ランダムに1枚選んでダウンロード
+        hit = random.choice(hits)
+        img_url = hit.get("largeImageURL") or hit.get("webformatURL")
+        if not img_url:
+            return False
+        img_r = requests.get(img_url, timeout=30)
+        if img_r.status_code == 200 and len(img_r.content) > 1000:
+            if save_image_bytes(img_r.content, filepath):
+                size_kb = len(img_r.content) // 1024
+                print(f"    ✅ Pixabay成功: {filepath} ({size_kb}KB) [{hit.get('pageURL','')[:60]}]", flush=True)
+                return True
+    except Exception as e:
+        print(f"    例外: {type(e).__name__}: {e}", flush=True)
     return False
 
 
@@ -162,11 +183,18 @@ def main() -> None:
             os.environ.get("GEMINI_API_KEY_3", ""),
         ] if k
     ]
+    pixabay_key = os.environ.get("PIXABAY_API_KEY", "")
     hf_token = os.environ.get("HF_TOKEN", "")
+
     print(f"Gemini APIキー: {len(gemini_keys)} 件ロード", flush=True)
+    print(f"Pixabay: {'あり' if pixabay_key else 'なし（PIXABAY_API_KEY未設定）'}", flush=True)
     print(f"HuggingFace: {'あり' if hf_token else 'なし'}", flush=True)
 
-    # プロンプト生成
+    if not pixabay_key and not hf_token:
+        print("[警告] Pixabay・HuggingFace どちらも未設定。グラデーション背景にフォールバックします。", flush=True)
+        sys.exit(0)
+
+    # プロンプト生成（Pixabayクエリにも活用）
     try:
         news_items = json.loads(Path(NEWS_JSON).read_text(encoding="utf-8"))
     except Exception:
@@ -177,24 +205,27 @@ def main() -> None:
     for i, p in enumerate(prompts, 1):
         print(f"    [{i}] {p[:80]}", flush=True)
 
-    # 画像生成（並列）: Pollinations → HF の順にフォールバック
+    # 画像生成（並列）: Pixabay → HF の順にフォールバック
     def generate_one(args):
         i, prompt = args
         out_path = str(ASSETS_DIR / f"ai_{i}.jpg")
-        print(f"\n  [{i}/4] 画像生成中...", flush=True)
+        query = PIXABAY_QUERIES[(i - 1) % len(PIXABAY_QUERIES)]
+        print(f"\n  [{i}/4] 画像取得中...", flush=True)
 
-        # 1st: Pollinations.ai（無料・認証不要）
-        print(f"  [{i}] → Pollinations.ai を試行", flush=True)
-        if generate_via_pollinations(prompt, out_path):
-            return i, True
+        # 1st: Pixabay（無料・実写写真）
+        if pixabay_key:
+            print(f"  [{i}] → Pixabay を試行 (query='{query}')", flush=True)
+            if generate_via_pixabay(pixabay_key, query, out_path):
+                return i, True
+            print(f"  [{i}] → Pixabay失敗。", flush=True)
 
-        # 2nd: HuggingFace（トークンがある場合）
+        # 2nd: HuggingFace
         if hf_token:
-            print(f"  [{i}] → Pollinations失敗。HuggingFace にフォールバック", flush=True)
+            print(f"  [{i}] → HuggingFace にフォールバック", flush=True)
             if generate_via_huggingface(hf_token, prompt, out_path):
                 return i, True
 
-        print(f"  [{i}] → 全手段で画像生成失敗", flush=True)
+        print(f"  [{i}] → 全手段で画像取得失敗", flush=True)
         return i, False
 
     failed = []
@@ -210,7 +241,7 @@ def main() -> None:
     print(f"  生成ファイル: {[f.name for f in ai_files]}", flush=True)
 
     if failed:
-        print(f"[エラー] {len(failed)}枚の生成失敗（インデックス: {failed}）", file=sys.stderr)
+        print(f"[エラー] {len(failed)}枚の取得失敗（インデックス: {failed}）", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
## 変更内容

Pollinations.ai が GitHub Actions の IP をブロックしているため、Pixabay API に切り替え。

**優先順位:**
1. **Pixabay API**（無料・実写競馬写真・`PIXABAY_API_KEY` 必要）
2. **HuggingFace**（フォールバック）
3. **グラデーション背景**（両方なし/失敗時）

## セットアップ

1. https://pixabay.com/accounts/register/ で無料アカウント作成
2. https://pixabay.com/api/docs/ で API キーを取得
3. GitHub Secrets に `PIXABAY_API_KEY` を追加