### PR TITLE
Yahoo ニュース直接スクレイピングを追加

### DIFF
--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -29,6 +29,8 @@ RSS_FEEDS = [
     "https://news.google.com/rss/search?q=%E9%87%8D%E8%B3%9E+%E7%AB%B6%E9%A6%AC+%E5%8B%9D%E5%88%A9&hl=ja&gl=JP&ceid=JP:ja",
     "https://news.google.com/rss/search?q=%E7%AB%B6%E9%A6%AC+%E3%83%AC%E3%83%BC%E3%82%B9%E7%B5%90%E6%9E%9C&hl=ja&gl=JP&ceid=JP:ja",
     "https://news.google.com/rss/search?q=JRA+%E7%AB%B6%E9%A6%AC+%E9%A8%8E%E6%89%8B&hl=ja&gl=JP&ceid=JP:ja",
+    # --- Yahoo ニュース（Google News 経由）---
+    "https://news.google.com/rss/search?q=%E7%AB%B6%E9%A6%AC+news.yahoo.co.jp&hl=ja&gl=JP&ceid=JP:ja",
 ]
 
 NEWS_JSON = "news.json"
@@ -733,6 +735,150 @@ def scrape_jra_news() -> list[dict]:
     return []
 
 
+def scrape_yahoo_news() -> list[dict]:
+    """Yahoo ニュース Japan の競馬検索ページを直接スクレイピングする。
+    Yahoo Japan は RSS を廃止しているため HTML を解析して記事リストを取得する。
+    Next.js の __NEXT_DATA__ JSON → href パターン の順に試みる。"""
+    from urllib.parse import urljoin, quote
+
+    YAHOO_BASE = "https://news.yahoo.co.jp"
+    search_query = quote("競馬")
+    urls_to_try = [
+        f"{YAHOO_BASE}/search?p={search_query}&ei=UTF-8",
+        f"{YAHOO_BASE}/topics/horse-racing",
+        f"{YAHOO_BASE}/search?p={quote('競馬 レース')}&ei=UTF-8",
+    ]
+
+    YAHOO_HEADERS = {
+        **HEADERS,
+        "Referer": "https://news.yahoo.co.jp/",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "ja-JP,ja;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Cookie": "B=; T=; Y=",
+    }
+
+    def _extract_articles_from_next_data(html: str) -> list[dict]:
+        """__NEXT_DATA__ JSON を再帰的に探索して記事リストを構築する。"""
+        m = re.search(
+            r'<script[^>]+id=["\']__NEXT_DATA__["\'][^>]*>\s*(\{.*?\})\s*</script>',
+            html, re.DOTALL | re.IGNORECASE,
+        )
+        if not m:
+            return []
+        try:
+            data = json.loads(m.group(1))
+        except (json.JSONDecodeError, ValueError):
+            return []
+
+        articles: list[dict] = []
+        seen_urls: set[str] = set()
+
+        def _walk(obj, depth: int = 0) -> None:
+            if depth > 15 or not obj:
+                return
+            if isinstance(obj, dict):
+                url = obj.get("url") or obj.get("link") or obj.get("articleUrl") or ""
+                title = obj.get("title") or obj.get("headline") or ""
+                # Yahoo 記事 URL パターンに一致するかチェック
+                if (
+                    isinstance(url, str)
+                    and "yahoo.co.jp/articles/" in url
+                    and isinstance(title, str)
+                    and len(title) >= 5
+                    and url not in seen_urls
+                ):
+                    seen_urls.add(url)
+                    summary = (
+                        obj.get("description") or obj.get("summary")
+                        or obj.get("body") or ""
+                    )
+                    if not isinstance(summary, str):
+                        summary = ""
+                    image_url = ""
+                    thumbnail = obj.get("thumbnail") or obj.get("image") or {}
+                    if isinstance(thumbnail, dict):
+                        image_url = thumbnail.get("url") or thumbnail.get("src") or ""
+                    elif isinstance(thumbnail, str):
+                        image_url = thumbnail
+                    pub_raw = (
+                        obj.get("publishedAt") or obj.get("published")
+                        or obj.get("createdAt") or ""
+                    )
+                    published_dt = _parse_date(pub_raw) if pub_raw else None
+                    articles.append({
+                        "id": url,
+                        "title": title.strip(),
+                        "link": url,
+                        "summary": summary.strip(),
+                        "image_url": image_url,
+                        "published_date": published_dt,
+                    })
+                for val in obj.values():
+                    _walk(val, depth + 1)
+            elif isinstance(obj, list):
+                for item in obj:
+                    _walk(item, depth + 1)
+
+        _walk(data)
+        return articles
+
+    def _extract_articles_from_html(html: str, base_url: str) -> list[dict]:
+        """href パターンで Yahoo 記事 URL とタイトルを抽出するフォールバック。"""
+        articles: list[dict] = []
+        seen_urls: set[str] = set()
+        # <a href="/articles/..." ...>タイトル</a> もしくは絶対URL
+        for m in re.finditer(
+            r'<a\s[^>]*href=["\']((https://news\.yahoo\.co\.jp)?/articles/([a-z0-9]+))["\'][^>]*>([^<]{5,100})</a>',
+            html, re.IGNORECASE,
+        ):
+            path, _, article_id, title = m.group(1), m.group(2), m.group(3), m.group(4)
+            url = path if path.startswith("http") else urljoin(base_url, path)
+            title = re.sub(r"\s+", " ", title).strip()
+            if url in seen_urls or not title:
+                continue
+            seen_urls.add(url)
+            articles.append({
+                "id": url,
+                "title": title,
+                "link": url,
+                "summary": "",
+                "image_url": "",
+                "published_date": None,
+            })
+        return articles
+
+    for page_url in urls_to_try:
+        print(f"  [YahooNews] 取得中: {page_url}")
+        try:
+            session = _requests.Session()
+            session.headers.update(YAHOO_HEADERS)
+            resp = session.get(page_url, timeout=20, allow_redirects=True)
+            print(f"  [YahooNews] status={resp.status_code} size={len(resp.content)} bytes")
+            if resp.status_code >= 400:
+                print(f"  [YahooNews] HTTP {resp.status_code}。スキップ。", file=sys.stderr)
+                continue
+            html = resp.content.decode("utf-8", errors="replace")
+        except Exception as e:
+            print(f"  [YahooNews] 取得例外: {e}", file=sys.stderr)
+            continue
+
+        # 1st: __NEXT_DATA__ から抽出
+        articles = _extract_articles_from_next_data(html)
+        if articles:
+            print(f"  [YahooNews] __NEXT_DATA__ から {len(articles)} 件取得")
+            return articles[:20]
+
+        # 2nd: href パターンで抽出
+        articles = _extract_articles_from_html(html, page_url)
+        if articles:
+            print(f"  [YahooNews] href パターンから {len(articles)} 件取得")
+            return articles[:20]
+
+        print(f"  [YahooNews] {page_url} から記事抽出できず。次URLへ。", file=sys.stderr)
+
+    print(f"  [YahooNews] 全URL失敗。スキップ。", file=sys.stderr)
+    return []
+
 
 # ---------------------------------------------------------------------------
 # OG画像抽出
@@ -811,7 +957,12 @@ def fetch_news() -> list[dict]:
     jra_entries = scrape_jra_news()
     all_entries.extend(jra_entries)
 
-    if feed_errors == len(RSS_FEEDS) and not jra_entries and not gnews_api_entries:
+    # Yahoo ニュース直接スクレイピング
+    print("Yahoo ニュースをスクレイピング中...")
+    yahoo_entries = scrape_yahoo_news()
+    all_entries.extend(yahoo_entries)
+
+    if feed_errors == len(RSS_FEEDS) and not jra_entries and not gnews_api_entries and not yahoo_entries:
         print("[エラー] 全フィードの取得に失敗しました。", file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
- scrape_yahoo_news() 関数を追加: Next.js __NEXT_DATA__ JSON → href パターンの2段階で記事を抽出
- RSS_FEEDS に Google News 経由の Yahoo ニュースクエリを追加
- fetch_news() から yahoo_entries を収集・統合するよう変更

https://claude.ai/code/session_01MHU2jGyJdMp6tXkp2DUxFY