### PR TITLE
fix: 斜め字幕を廃止・子馬画像を除外

### DIFF
--- a/scripts/generate_images.py
+++ b/scripts/generate_images.py
@@ -255,7 +255,7 @@ def save_image_bytes(content: bytes, filepath: str) -> bool:
 
 def generate_via_pixabay(api_key: str, query: str, filepath: str) -> bool:
     """Pixabay API で競馬写真を取得して保存する。"""
-    EXCLUDE_TAGS = {"zebra", "donkey", "mule", "pony", "ass"}
+    EXCLUDE_TAGS = {"zebra", "donkey", "mule", "pony", "ass", "foal", "colt", "filly", "baby"}
     page = random.randint(1, 5)
     params = {
         "key": api_key,

--- a/scripts/generate_video.py
+++ b/scripts/generate_video.py
@@ -435,10 +435,10 @@ _BG_PATTERNS: list[str] = _build_bg_patterns()
 def make_video_style() -> dict:
     """動画ごとのランダムスタイルを生成する。"""
     sub_box = random.choice(_BOX_COLORS)
-    # 字幕スタイルタイプ: box(ボックスあり) / no_box(影のみ) / diagonal(斜め)
+    # 字幕スタイルタイプ: box(ボックスあり) / no_box(影のみ)
     sub_type = random.choices(
-        ["box", "no_box", "diagonal"],
-        weights=[5, 3, 2],
+        ["box", "no_box"],
+        weights=[6, 4],
         k=1,
     )[0]
     # 字幕の縦位置（画面下からの距離）


### PR DESCRIPTION
## 変更内容

- `diagonal`（斜め）字幕スタイルを廃止。ニュース動画では読みにくいため `box` / `no_box` のみに変更
- Pixabay除外タグに `foal` / `colt` / `filly` / `baby` を追加し、子馬・幼駒画像の混入を防止