### PR TITLE
fix: misaki[ja_espeak]を追加してKokoro日本語TTSを修正

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 google-generativeai==0.8.3
 edge-tts
 kokoro>=0.9.4
+misaki[ja_espeak]
 soundfile
 google-api-python-client==2.151.0
 google-auth==2.35.0


### PR DESCRIPTION
Kokoro TTSが `No module named 'pyopenjtalk'` で失敗していた問題を修正。`misaki[ja_espeak]` を追加して espeak-ng ベースのフォネマイザーを使用。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaKTmrjW19zAVRRiA7e7L4)_