### PR TITLE
fix: pyopenjtalkを追加してKokoro日本語TTS対応

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 google-generativeai==0.8.3
 edge-tts
 kokoro>=0.9.4
+pyopenjtalk
 soundfile
 google-api-python-client==2.151.0
 google-auth==2.35.0


### PR DESCRIPTION
Kokoro日本語TTSが `No module named 'pyopenjtalk'` で失敗していた問題を修正。`pyopenjtalk` をPyPIのビルド済みホイールで直接インストール。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaKTmrjW19zAVRRiA7e7L4)_