### PR TITLE
fix: misaki[ja]でKokoro日本語依存を一括インストール

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 google-generativeai==0.8.3
 edge-tts
 kokoro>=0.9.4
-pyopenjtalk
+misaki[ja]
 soundfile
 google-api-python-client==2.151.0
 google-auth==2.35.0


### PR DESCRIPTION
`pyopenjtalk`単体では`fugashi`が不足してKokoro日本語TTSが失敗していた。`misaki[ja]`はpyopenjtalk・fugashi・辞書データ(unidic-lite)を一括でインストールする。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaKTmrjW19zAVRRiA7e7L4)_