### PR TITLE
fix: クイズ動画の追加問題修正（レイアウト・BGM・説明・空白画面）

### DIFF
--- a/.github/workflows/quiz_video.yml
+++ b/.github/workflows/quiz_video.yml
@@ -48,6 +48,13 @@ jobs:
           PYTHONUNBUFFERED: '1'
         run: python scripts/quiz_step2_slides.py
 
+      - name: BGM ダウンロード (archive.org Musopen CC0)
+        env:
+          PYTHONUNBUFFERED: '1'
+        run: |
+          mkdir -p assets/bgm
+          python scripts/download_bgm.py || echo "BGMダウンロード失敗（動画は BGM なしで継続）"
+
       - name: Step 3 動画生成
         env:
           PYTHONUNBUFFERED: '1'

--- a/scripts/quiz_step1_questions.py
+++ b/scripts/quiz_step1_questions.py
@@ -82,7 +82,8 @@ def main():
     print(f"  {len(questions)}問生成されました")
 
     for q in questions:
-        print(f"  Q{q['number']}: {q['display_question']}")
+        correct = q["choices"][q["correct_index"]]
+        print(f"  Q{q['number']}: {correct}（正解）")
 
     with open("quiz.json", "w", encoding="utf-8") as f:
         json.dump(quiz, f, ensure_ascii=False, indent=2)

--- a/scripts/quiz_step2_slides.py
+++ b/scripts/quiz_step2_slides.py
@@ -56,7 +56,7 @@ def setup_japanese_font():
     return False
 
 
-def draw_banner(ax, text, bg=ACCENT, fg="#0d1b2a", fontsize=30):
+def draw_banner(ax, text, bg=ACCENT, fg="#0d1b2a", fontsize=34):
     ax.add_patch(mpatches.FancyBboxPatch(
         (0.0, 0.895), 1.0, 0.105,
         boxstyle="square,pad=0",
@@ -66,18 +66,19 @@ def draw_banner(ax, text, bg=ACCENT, fg="#0d1b2a", fontsize=30):
             color=fg, fontsize=fontsize, fontweight="bold", transform=ax.transAxes)
 
 
-def draw_choice_box(ax, x, y, w, h, label, text, bg, border, fontsize=22):
+def draw_choice_box(ax, x, y, w, h, label, text, bg, border, fontsize=26):
+    # zorder=5 でクルーテキスト（default zorder=3）の上に描画
     ax.add_patch(mpatches.FancyBboxPatch(
         (x, y), w, h,
         boxstyle="round,pad=0.01",
         facecolor=bg, edgecolor=border, linewidth=2,
+        zorder=5,
     ))
-    # ラベル円
-    ax.add_patch(plt.Circle((x + 0.035, y + h / 2), 0.028, color=border, zorder=3))
-    ax.text(x + 0.035, y + h / 2, label, ha="center", va="center",
-            color=WHITE, fontsize=fontsize - 2, fontweight="bold", zorder=4)
-    ax.text(x + 0.085, y + h / 2, text, ha="left", va="center",
-            color=WHITE, fontsize=fontsize)
+    ax.add_patch(plt.Circle((x + 0.038, y + h / 2), 0.030, color=border, zorder=6))
+    ax.text(x + 0.038, y + h / 2, label, ha="center", va="center",
+            color=WHITE, fontsize=fontsize - 2, fontweight="bold", zorder=7)
+    ax.text(x + 0.090, y + h / 2, text, ha="left", va="center",
+            color=WHITE, fontsize=fontsize, zorder=7)
 
 
 def make_question_slide(q: dict, out_path: Path):
@@ -90,52 +91,51 @@ def make_question_slide(q: dict, out_path: Path):
 
     draw_banner(ax, f"名馬当てクイズ  ─  第{q['number']}問")
 
-    # 「この馬は誰？」
-    ax.text(0.5, 0.82, "この馬は誰？", ha="center", va="center",
-            color=ACCENT, fontsize=36, fontweight="bold")
+    # 「この馬は誰？」 + 問題番号
+    ax.text(0.5, 0.858, "この馬は誰？", ha="center", va="center",
+            color=ACCENT, fontsize=44, fontweight="bold")
+    ax.text(0.97, 0.858, f"{q['number']} / 5問", ha="right", va="center",
+            color="#8090a0", fontsize=22)
 
     # G1勝利歴（全件・2列レイアウト）
     clues = q["clues"]
     ax.add_patch(mpatches.FancyBboxPatch(
-        (0.03, 0.38), 0.94, 0.42,
+        (0.03, 0.46), 0.94, 0.37,
         boxstyle="round,pad=0.015",
         facecolor=CLUE_BG, edgecolor=ACCENT, linewidth=1.5,
+        zorder=2,
     ))
-    ax.text(0.5, 0.77, "G1 勝利歴", ha="center", va="center",
-            color=ACCENT, fontsize=20, fontweight="bold")
+    ax.text(0.5, 0.81, "G1 勝利歴", ha="center", va="center",
+            color=ACCENT, fontsize=26, fontweight="bold", zorder=3)
 
     # 2列に分割
     half = (len(clues) + 1) // 2
     col_left = clues[:half]
     col_right = clues[half:]
-    row_h = min(0.30 / max(half, 1), 0.07)
-    base_y = 0.71 - row_h
+    row_h = min(0.24 / max(half, 1), 0.070)
+    base_y = 0.76 - row_h
 
     for i, clue in enumerate(col_left):
         y = base_y - i * row_h
-        ax.text(0.06, y, f"◆ {clue}", ha="left", va="center",
-                color=WHITE, fontsize=19, fontweight="bold")
+        ax.text(0.07, y, f"◆ {clue}", ha="left", va="center",
+                color=WHITE, fontsize=22, fontweight="bold", zorder=3)
     for i, clue in enumerate(col_right):
         y = base_y - i * row_h
-        ax.text(0.54, y, f"◆ {clue}", ha="left", va="center",
-                color=WHITE, fontsize=19, fontweight="bold")
+        ax.text(0.55, y, f"◆ {clue}", ha="left", va="center",
+                color=WHITE, fontsize=22, fontweight="bold", zorder=3)
 
-    # 4択（2×2グリッド）
+    # 4択（2×2グリッド）― choiceはクルーパネルより下に配置
     choices = q["choices"]
-    box_w, box_h = 0.44, 0.10
+    box_w, box_h = 0.44, 0.13
     positions = [
-        (0.03, 0.38), (0.53, 0.38),
-        (0.03, 0.26), (0.53, 0.26),
+        (0.03, 0.31), (0.53, 0.31),  # 上段: y=0.31-0.44
+        (0.03, 0.15), (0.53, 0.15),  # 下段: y=0.15-0.28
     ]
     for i, (bx, by) in enumerate(positions):
         if i < len(choices):
             draw_choice_box(ax, bx, by, box_w, box_h,
                             CHOICE_LABELS[i], choices[i],
-                            CHOICE_BG, CHOICE_BORDER, fontsize=24)
-
-    # プログレス
-    ax.text(0.97, 0.03, f"{q['number']} / 5問", ha="right", va="center",
-            color="#606080", fontsize=20)
+                            CHOICE_BG, CHOICE_BORDER, fontsize=26)
 
     plt.tight_layout(pad=0)
     fig.savefig(out_path, dpi=DPI, bbox_inches="tight", facecolor=BG)
@@ -161,12 +161,12 @@ def make_answer_slide(q: dict, out_path: Path):
     # 正解ラベル
     ax.text(0.5, 0.82, f"正解は  {correct_label}. {correct_name}！",
             ha="center", va="center",
-            color="#2ecc71", fontsize=38, fontweight="bold")
+            color="#2ecc71", fontsize=44, fontweight="bold")
 
     # 4択（正解=緑、不正解=暗赤色）
-    box_w, box_h = 0.44, 0.10
+    box_w, box_h = 0.44, 0.11
     positions = [
-        (0.03, 0.56), (0.53, 0.56),
+        (0.03, 0.57), (0.53, 0.57),
         (0.03, 0.44), (0.53, 0.44),
     ]
     for i, (bx, by) in enumerate(positions):
@@ -177,21 +177,22 @@ def make_answer_slide(q: dict, out_path: Path):
                 bg, border = WRONG_BG, WRONG_BORDER
             draw_choice_box(ax, bx, by, box_w, box_h,
                             CHOICE_LABELS[i], choices[i],
-                            bg, border, fontsize=24)
+                            bg, border, fontsize=26)
 
     # 解説パネル
     ax.add_patch(mpatches.FancyBboxPatch(
-        (0.03, 0.10), 0.94, 0.26,
+        (0.03, 0.09), 0.94, 0.27,
         boxstyle="round,pad=0.015",
         facecolor=PANEL, edgecolor="#304060", linewidth=1,
+        zorder=2,
     ))
-    ax.text(0.06, 0.32, "◆ 解説", ha="left", va="center",
-            color=ACCENT, fontsize=20, fontweight="bold")
+    ax.text(0.07, 0.33, "◆ 解説", ha="left", va="center",
+            color=ACCENT, fontsize=24, fontweight="bold", zorder=3)
     ax.text(0.5, 0.20, q["display_explanation"], ha="center", va="center",
-            color=WHITE, fontsize=26, multialignment="center")
+            color=WHITE, fontsize=28, multialignment="center", zorder=3)
 
     ax.text(0.97, 0.03, f"{q['number']} / 5問", ha="right", va="center",
-            color="#606080", fontsize=20)
+            color="#606080", fontsize=22)
 
     plt.tight_layout(pad=0)
     fig.savefig(out_path, dpi=DPI, bbox_inches="tight", facecolor=BG)
@@ -207,20 +208,23 @@ def make_title_slide(title: str, out_path: Path):
     ax.set_ylim(0, 1)
     ax.axis("off")
 
-    draw_banner(ax, "競馬チャンネル")
+    # チャンネル名ではなくクイズタイトルをバナーに表示
+    draw_banner(ax, "名馬当てクイズ")
 
     ax.add_patch(mpatches.FancyBboxPatch(
-        (0.05, 0.34), 0.90, 0.44,
+        (0.05, 0.20), 0.90, 0.62,
         boxstyle="round,pad=0.02",
         facecolor=PANEL, edgecolor=ACCENT, linewidth=3,
     ))
-    ax.text(0.50, 0.65, title, ha="center", va="center",
-            color=ACCENT, fontsize=38, fontweight="bold", multialignment="center")
-    ax.text(0.50, 0.48, "全5問  ─  あなたは何問わかる？", ha="center", va="center",
-            color=WHITE, fontsize=26)
+    ax.text(0.50, 0.68, title, ha="center", va="center",
+            color=ACCENT, fontsize=44, fontweight="bold", multialignment="center")
+    ax.text(0.50, 0.54, "G1勝利歴のヒントから名馬を当てよう！", ha="center", va="center",
+            color=WHITE, fontsize=30)
+    ax.text(0.50, 0.40, "全5問  ─  制限時間 15秒！", ha="center", va="center",
+            color=ACCENT, fontsize=28)
 
-    ax.text(0.5, 0.16, "チャンネル登録・高評価よろしくお願いします！",
-            ha="center", va="center", color="#8090a0", fontsize=22)
+    ax.text(0.5, 0.09, "チャンネル登録・高評価よろしくお願いします！",
+            ha="center", va="center", color="#8090a0", fontsize=24)
 
     plt.tight_layout(pad=0)
     fig.savefig(out_path, dpi=DPI, bbox_inches="tight", facecolor=BG)
@@ -239,17 +243,17 @@ def make_result_slide(out_path: Path):
     draw_banner(ax, "名馬当てクイズ  ─  全問終了！")
 
     ax.add_patch(mpatches.FancyBboxPatch(
-        (0.05, 0.34), 0.90, 0.44,
+        (0.05, 0.20), 0.90, 0.62,
         boxstyle="round,pad=0.02",
         facecolor=PANEL, edgecolor=ACCENT, linewidth=2,
     ))
-    ax.text(0.50, 0.65, "全問終了！", ha="center", va="center",
-            color=ACCENT, fontsize=44, fontweight="bold")
-    ax.text(0.50, 0.50, "いくつ正解できましたか？", ha="center", va="center",
-            color=WHITE, fontsize=28)
+    ax.text(0.50, 0.68, "全問終了！", ha="center", va="center",
+            color=ACCENT, fontsize=48, fontweight="bold")
+    ax.text(0.50, 0.52, "いくつ正解できましたか？", ha="center", va="center",
+            color=WHITE, fontsize=32)
 
-    ax.text(0.5, 0.16, "高評価 & チャンネル登録お願いします！　次回もお楽しみに！",
-            ha="center", va="center", color="#9090b0", fontsize=22)
+    ax.text(0.5, 0.09, "高評価 & チャンネル登録お願いします！　次回もお楽しみに！",
+            ha="center", va="center", color="#9090b0", fontsize=24)
 
     plt.tight_layout(pad=0)
     fig.savefig(out_path, dpi=DPI, bbox_inches="tight", facecolor=BG)

--- a/scripts/quiz_step3_video.py
+++ b/scripts/quiz_step3_video.py
@@ -2,8 +2,10 @@
 """Step 3: quiz.json + slides/ から音声合成・動画組み立てを行い quiz_video.mp4 に保存"""
 
 import asyncio
+import glob
 import json
 import os
+import random
 import subprocess
 import sys
 import tempfile
@@ -21,6 +23,9 @@ TITLE_DURATION = 4
 THINK_DURATION = 15   # シンキングタイム（カウントダウン表示）
 ANSWER_EXTRA = 1      # 回答読み上げ後の余韻
 RESULT_DURATION = 5
+
+# BGM 設定
+BGM_VOL = 0.12
 
 # 動画設定
 FPS = 30
@@ -56,15 +61,17 @@ async def synthesize_all(quiz: dict):
     tasks = []
     paths = []
 
-    # タイトル TTS
+    # タイトル TTS（ルール説明含む）
     title_audio = AUDIO_DIR / "00_title.mp3"
     tasks.append(synthesize_one(
-        f"競馬知識クイズ、始めます！全{len(quiz['questions'])}問、何問正解できるか挑戦してみてください！",
+        f"名馬当てクイズ、スタートです！"
+        f"G1の勝利歴ヒントから名馬を当ててください。"
+        f"全{len(quiz['questions'])}問、制限時間は15秒！さあ、挑戦してみましょう！",
         TTS_VOICE, title_audio
     ))
     paths.append(("title", title_audio))
 
-    # 各問TTS（問題文は読まない：シンキングタイムで視聴者が自分で読む）
+    # 各問TTS（問題文は読まない、解説込みの回答のみ）
     for q in quiz["questions"]:
         a_audio = AUDIO_DIR / f"{q['number']:02d}a.mp3"
         tasks.append(synthesize_one(q["tts_answer"], TTS_VOICE, a_audio))
@@ -85,21 +92,20 @@ async def synthesize_all(quiz: dict):
 
 
 def get_audio_duration(audio_path: Path) -> float:
-    """ffprobe で音声の長さを取得"""
+    """ffprobe で音声/動画の長さを取得（format=duration が最も信頼性が高い）"""
     result = subprocess.run(
         [
-            "ffprobe", "-v", "quiet",
-            "-print_format", "json",
-            "-show_streams",
+            "ffprobe", "-v", "error",
+            "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1",
             str(audio_path),
         ],
         capture_output=True, text=True
     )
-    data = json.loads(result.stdout)
-    for stream in data.get("streams", []):
-        if "duration" in stream:
-            return float(stream["duration"])
-    return 3.0
+    try:
+        return float(result.stdout.strip())
+    except ValueError:
+        return 3.0
 
 
 def make_clip(slide_path: Path, audio_path: Path | None, extra_secs: float, out_path: Path):
@@ -125,7 +131,7 @@ def make_clip(slide_path: Path, audio_path: Path | None, extra_secs: float, out_
             "-vf", f"scale={WIDTH}:{HEIGHT}:force_original_aspect_ratio=decrease,pad={WIDTH}:{HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=#0d1b2a",
             "-c:a", "aac",
             "-b:a", "128k",
-            "-af", f"apad=whole_dur={duration}",
+            "-af", f"apad=whole_dur={duration:.3f}",
             "-t", str(duration),
         ]
     else:
@@ -147,9 +153,14 @@ def make_clip(slide_path: Path, audio_path: Path | None, extra_secs: float, out_
 
 
 def make_question_silence_clip(slide_path: Path, out_path: Path, duration: float = 15.0):
-    """問題スライド + カウントダウンタイマーの無音クリップ（シンキングタイム）"""
+    """問題スライド + カウントダウンタイマーの無音クリップ（シンキングタイム）
+
+    カウントダウンは問題スライドの下部空きスペース（choice下段より下）に配置。
+    下段 choice の下端: y=0.15 → 画面上端から (1-0.15)*1080=918px の位置。
+    """
     duration_int = int(duration)
-    countdown_text = "%{eif\\:" + str(duration_int) + "-t\\:d}"
+    # floor(t) で1秒ごとに整数が変わるカウントダウン (15→14→...→0)
+    countdown_text = r"%{eif\:" + str(duration_int) + r"-floor(t)\:d}"
 
     font_path = find_noto_font()
 
@@ -157,11 +168,13 @@ def make_question_silence_clip(slide_path: Path, out_path: Path, duration: float
         f"scale={WIDTH}:{HEIGHT}:force_original_aspect_ratio=decrease,"
         f"pad={WIDTH}:{HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=#0d1b2a"
     )
+    # カウントダウン数字: 下段choice下端(918px)より下に配置
+    # center at h*0.935 = 1010px (fontsize=95 → height≈95px → top 963px, bottom 1058px)
     countdown_f = (
         f"drawtext=text='{countdown_text}':"
-        f"fontsize=180:fontcolor=white@0.95:"
-        f"x=(w-tw)/2:y=h*0.82-th/2:"
-        f"box=1:boxcolor=black@0.55:boxborderw=35"
+        f"fontsize=95:fontcolor=white@0.95:"
+        f"x=(w-tw)/2:y=h*0.935-th/2:"
+        f"box=1:boxcolor=black@0.55:boxborderw=25"
     )
 
     if font_path:
@@ -170,11 +183,12 @@ def make_question_silence_clip(slide_path: Path, out_path: Path, duration: float
         ) as tf:
             tf.write("シンキングタイム")
             label_file = tf.name
+        # ラベル: center at h*0.875 = 945px (fontsize=50 → top 920px > 918px ✓)
         label_f = (
             f"drawtext=fontfile={font_path}:"
             f"textfile={label_file}:"
-            f"fontsize=58:fontcolor=#e8c84a:"
-            f"x=(w-tw)/2:y=h*0.73-th/2"
+            f"fontsize=50:fontcolor=#e8c84a:"
+            f"x=(w-tw)/2:y=h*0.875-th/2"
         )
         vf = f"{scale_f},{countdown_f},{label_f}"
     else:
@@ -228,6 +242,39 @@ def concat_clips(clip_paths: list[Path], out_path: Path):
         os.unlink(list_file)
 
 
+def add_bgm(video_path: Path, out_path: Path) -> bool:
+    """BGMを動画にミックス（ニュース系と同じ方法: amix weights=1 BGM_VOL）"""
+    bgm_files = sorted(
+        glob.glob("assets/bgm/*.mp3") + glob.glob("assets/bgm/*.m4a")
+    )
+    if not bgm_files:
+        print("  BGMなし: assets/bgm/ に mp3 を置くと自動適用")
+        return False
+    bgm_path = random.choice(bgm_files)
+    print(f"  BGM: {Path(bgm_path).name} (vol={BGM_VOL})")
+
+    total_dur = get_audio_duration(video_path)
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", str(video_path),
+        "-stream_loop", "-1", "-i", bgm_path,
+        "-filter_complex",
+        f"[0:a]apad=whole_dur={total_dur:.3f}[narr];"
+        f"[narr][1:a]amix=inputs=2:duration=first:weights=1 {BGM_VOL}[aout]",
+        "-map", "0:v",
+        "-map", "[aout]",
+        "-c:v", "copy",
+        "-c:a", "aac",
+        "-b:a", "192k",
+        str(out_path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  BGM追加失敗: {result.stderr[-300:]}", file=sys.stderr)
+        return False
+    return True
+
+
 def main():
     print("=== Step 3: 動画生成 ===")
 
@@ -268,7 +315,7 @@ def main():
 
     for q in questions:
         n = q["number"]
-        print(f"  Q{n} 問題クリップ...")
+        print(f"  Q{n} 問題クリップ（シンキングタイム{THINK_DURATION}秒）...")
 
         # シンキングタイムクリップ（カウントダウン表示・問題文は読まない）
         q_think_clip = clips_dir / f"{n:02d}q_think.mp4"
@@ -304,6 +351,12 @@ def main():
     # --- 結合 ---
     print("③ クリップ結合中...")
     concat_clips(clip_paths, OUTPUT_VIDEO)
+
+    # --- BGM追加 ---
+    print("④ BGM追加中...")
+    bgm_out = OUTPUT_VIDEO.parent / (OUTPUT_VIDEO.stem + "_bgm.mp4")
+    if add_bgm(OUTPUT_VIDEO, bgm_out):
+        bgm_out.replace(OUTPUT_VIDEO)
 
     size_mb = OUTPUT_VIDEO.stat().st_size / 1024 / 1024
     print(f"\n{OUTPUT_VIDEO} に保存しました ({size_mb:.1f} MB)")


### PR DESCRIPTION
## 修正内容

- **レイアウト崩れ根本修正**: choiceボックスパッチにzorder=5を設定。matplotlibのデフォルトzorder(パッチ=1, テキスト=3)によりclueテキストがchoice上に被っていた
- **レイアウト再設計**: choiceを下部(y=0.31/0.15)に移動してclueパネルと分離。フォントサイズ全体拡大
- **空白画面修正**: `get_audio_duration`をffprobe `format=duration`に変更（VBR MP3で誤値を返す問題を解消）
- **カウントダウン位置修正**: シンキングタイムのffmpegオーバーレイをchoice下段より下に移動
- **BGM追加**: ニュース系と同じamixロジックでミックス。ワークフローにBGMダウンロードステップ追加
- **タイトル改善**: バナーを「競馬チャンネル」→「名馬当てクイズ」に変更。ルール説明をスライドとTTSに追加
- **step1バグ修正**: 存在しない`display_question`フィールド参照を修正

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg3Bi3L51qQetSqnMxGbMa)_