### PR TITLE
fix: 音ずれ・空白動画・音量・文字サイズの根本修正

### DIFF
--- a/scripts/quiz_step2_slides.py
+++ b/scripts/quiz_step2_slides.py
@@ -56,7 +56,7 @@ def setup_japanese_font():
     return False
 
 
-def draw_banner(ax, text, bg=ACCENT, fg="#0d1b2a", fontsize=34):
+def draw_banner(ax, text, bg=ACCENT, fg="#0d1b2a", fontsize=40):
     ax.add_patch(mpatches.FancyBboxPatch(
         (0.0, 0.895), 1.0, 0.105,
         boxstyle="square,pad=0",
@@ -93,9 +93,9 @@ def make_question_slide(q: dict, out_path: Path):
 
     # 「この馬は誰？」 + 問題番号
     ax.text(0.5, 0.858, "この馬は誰？", ha="center", va="center",
-            color=ACCENT, fontsize=44, fontweight="bold")
+            color=ACCENT, fontsize=52, fontweight="bold")
     ax.text(0.97, 0.858, f"{q['number']} / 5問", ha="right", va="center",
-            color="#8090a0", fontsize=22)
+            color="#8090a0", fontsize=26)
 
     # G1勝利歴（全件・2列レイアウト）
     clues = q["clues"]
@@ -106,7 +106,7 @@ def make_question_slide(q: dict, out_path: Path):
         zorder=2,
     ))
     ax.text(0.5, 0.81, "G1 勝利歴", ha="center", va="center",
-            color=ACCENT, fontsize=26, fontweight="bold", zorder=3)
+            color=ACCENT, fontsize=30, fontweight="bold", zorder=3)
 
     # 2列に分割
     half = (len(clues) + 1) // 2
@@ -118,11 +118,11 @@ def make_question_slide(q: dict, out_path: Path):
     for i, clue in enumerate(col_left):
         y = base_y - i * row_h
         ax.text(0.07, y, f"◆ {clue}", ha="left", va="center",
-                color=WHITE, fontsize=22, fontweight="bold", zorder=3)
+                color=WHITE, fontsize=26, fontweight="bold", zorder=3)
     for i, clue in enumerate(col_right):
         y = base_y - i * row_h
         ax.text(0.55, y, f"◆ {clue}", ha="left", va="center",
-                color=WHITE, fontsize=22, fontweight="bold", zorder=3)
+                color=WHITE, fontsize=26, fontweight="bold", zorder=3)
 
     # 4択（2×2グリッド）― choiceはクルーパネルより下に配置
     choices = q["choices"]
@@ -135,7 +135,7 @@ def make_question_slide(q: dict, out_path: Path):
         if i < len(choices):
             draw_choice_box(ax, bx, by, box_w, box_h,
                             CHOICE_LABELS[i], choices[i],
-                            CHOICE_BG, CHOICE_BORDER, fontsize=26)
+                            CHOICE_BG, CHOICE_BORDER, fontsize=30)
 
     plt.tight_layout(pad=0)
     fig.savefig(out_path, dpi=DPI, bbox_inches="tight", facecolor=BG)
@@ -161,7 +161,7 @@ def make_answer_slide(q: dict, out_path: Path):
     # 正解ラベル
     ax.text(0.5, 0.82, f"正解は  {correct_label}. {correct_name}！",
             ha="center", va="center",
-            color="#2ecc71", fontsize=44, fontweight="bold")
+            color="#2ecc71", fontsize=50, fontweight="bold")
 
     # 4択（正解=緑、不正解=暗赤色）
     box_w, box_h = 0.44, 0.11
@@ -177,7 +177,7 @@ def make_answer_slide(q: dict, out_path: Path):
                 bg, border = WRONG_BG, WRONG_BORDER
             draw_choice_box(ax, bx, by, box_w, box_h,
                             CHOICE_LABELS[i], choices[i],
-                            bg, border, fontsize=26)
+                            bg, border, fontsize=30)
 
     # 解説パネル
     ax.add_patch(mpatches.FancyBboxPatch(
@@ -187,12 +187,12 @@ def make_answer_slide(q: dict, out_path: Path):
         zorder=2,
     ))
     ax.text(0.07, 0.33, "◆ 解説", ha="left", va="center",
-            color=ACCENT, fontsize=24, fontweight="bold", zorder=3)
+            color=ACCENT, fontsize=28, fontweight="bold", zorder=3)
     ax.text(0.5, 0.20, q["display_explanation"], ha="center", va="center",
-            color=WHITE, fontsize=28, multialignment="center", zorder=3)
+            color=WHITE, fontsize=32, multialignment="center", zorder=3)
 
     ax.text(0.97, 0.03, f"{q['number']} / 5問", ha="right", va="center",
-            color="#606080", fontsize=22)
+            color="#606080", fontsize=24)
 
     plt.tight_layout(pad=0)
     fig.savefig(out_path, dpi=DPI, bbox_inches="tight", facecolor=BG)

--- a/scripts/quiz_step3_video.py
+++ b/scripts/quiz_step3_video.py
@@ -17,6 +17,7 @@ OUTPUT_VIDEO = Path("quiz_video.mp4")
 
 # TTS ボイス（競馬ニュース系は KeitaNeural 男性）
 TTS_VOICE = "ja-JP-KeitaNeural"
+TTS_VOLUME = "+50%"   # 音声が小さい場合に増幅
 
 # スライド表示時間（秒）
 TITLE_DURATION = 4
@@ -50,7 +51,7 @@ def find_noto_font() -> str | None:
 
 async def synthesize_one(text: str, voice: str, out_path: Path):
     import edge_tts
-    communicate = edge_tts.Communicate(text, voice)
+    communicate = edge_tts.Communicate(text, voice, volume=TTS_VOLUME)
     await communicate.save(str(out_path))
 
 
@@ -91,58 +92,43 @@ async def synthesize_all(quiz: dict):
     return paths
 
 
-def get_audio_duration(audio_path: Path) -> float:
-    """ffprobe で音声/動画の長さを取得（format=duration が最も信頼性が高い）"""
-    result = subprocess.run(
-        [
-            "ffprobe", "-v", "error",
-            "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1",
-            str(audio_path),
-        ],
-        capture_output=True, text=True
-    )
-    try:
-        return float(result.stdout.strip())
-    except ValueError:
-        return 3.0
-
-
 def make_clip(slide_path: Path, audio_path: Path | None, extra_secs: float, out_path: Path):
-    """スライド画像 + 音声から動画クリップを生成"""
-    if audio_path and audio_path.exists():
-        duration = get_audio_duration(audio_path) + extra_secs
-    else:
-        duration = extra_secs
+    """スライド画像 + 音声から動画クリップを生成。
 
+    apad=pad_dur + -shortest を使うことで、edge-tts MP3 の duration メタデータの
+    誤値（VBR推測値）に依存せず正確なクリップ長を得る。
+    """
     cmd = [
         "ffmpeg", "-y",
         "-loop", "1",
         "-i", str(slide_path),
     ]
 
+    scale_vf = (
+        f"scale={WIDTH}:{HEIGHT}:force_original_aspect_ratio=decrease,"
+        f"pad={WIDTH}:{HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=#0d1b2a"
+    )
+
     if audio_path and audio_path.exists():
         cmd += ["-i", str(audio_path)]
         cmd += [
-            "-c:v", "libx264",
-            "-preset", "ultrafast",
-            "-crf", "28",
+            "-c:v", "libx264", "-preset", "ultrafast", "-crf", "28",
             "-pix_fmt", "yuv420p",
-            "-vf", f"scale={WIDTH}:{HEIGHT}:force_original_aspect_ratio=decrease,pad={WIDTH}:{HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=#0d1b2a",
-            "-c:a", "aac",
-            "-b:a", "128k",
-            "-af", f"apad=whole_dur={duration:.3f}",
-            "-t", str(duration),
+            "-vf", scale_vf,
+            "-c:a", "aac", "-b:a", "128k",
+            # apad=pad_dur で音声末尾に extra_secs の無音を追加し、
+            # -shortest でその終端に合わせて映像を停止する。
+            # duration計算不要なため VBR MP3の誤duration問題を完全回避。
+            "-af", f"apad=pad_dur={extra_secs}",
+            "-shortest",
         ]
     else:
         cmd += [
-            "-c:v", "libx264",
-            "-preset", "ultrafast",
-            "-crf", "28",
+            "-c:v", "libx264", "-preset", "ultrafast", "-crf", "28",
             "-pix_fmt", "yuv420p",
-            "-vf", f"scale={WIDTH}:{HEIGHT}:force_original_aspect_ratio=decrease,pad={WIDTH}:{HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=#0d1b2a",
+            "-vf", scale_vf,
             "-an",
-            "-t", str(duration),
+            "-t", str(extra_secs),
         ]
 
     cmd.append(str(out_path))
@@ -153,13 +139,8 @@ def make_clip(slide_path: Path, audio_path: Path | None, extra_secs: float, out_
 
 
 def make_question_silence_clip(slide_path: Path, out_path: Path, duration: float = 15.0):
-    """問題スライド + カウントダウンタイマーの無音クリップ（シンキングタイム）
-
-    カウントダウンは問題スライドの下部空きスペース（choice下段より下）に配置。
-    下段 choice の下端: y=0.15 → 画面上端から (1-0.15)*1080=918px の位置。
-    """
+    """問題スライド + カウントダウンタイマーの無音クリップ（シンキングタイム）"""
     duration_int = int(duration)
-    # floor(t) で1秒ごとに整数が変わるカウントダウン (15→14→...→0)
     countdown_text = r"%{eif\:" + str(duration_int) + r"-floor(t)\:d}"
 
     font_path = find_noto_font()
@@ -168,8 +149,7 @@ def make_question_silence_clip(slide_path: Path, out_path: Path, duration: float
         f"scale={WIDTH}:{HEIGHT}:force_original_aspect_ratio=decrease,"
         f"pad={WIDTH}:{HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=#0d1b2a"
     )
-    # カウントダウン数字: 下段choice下端(918px)より下に配置
-    # center at h*0.935 = 1010px (fontsize=95 → height≈95px → top 963px, bottom 1058px)
+    # カウントダウン: choice下段底辺(918px from top)より下に配置
     countdown_f = (
         f"drawtext=text='{countdown_text}':"
         f"fontsize=95:fontcolor=white@0.95:"
@@ -183,7 +163,6 @@ def make_question_silence_clip(slide_path: Path, out_path: Path, duration: float
         ) as tf:
             tf.write("シンキングタイム")
             label_file = tf.name
-        # ラベル: center at h*0.875 = 945px (fontsize=50 → top 920px > 918px ✓)
         label_f = (
             f"drawtext=fontfile={font_path}:"
             f"textfile={label_file}:"
@@ -200,13 +179,10 @@ def make_question_silence_clip(slide_path: Path, out_path: Path, duration: float
         "-loop", "1",
         "-i", str(slide_path),
         "-f", "lavfi", "-i", "anullsrc=r=44100:cl=stereo",
-        "-c:v", "libx264",
-        "-preset", "ultrafast",
-        "-crf", "28",
+        "-c:v", "libx264", "-preset", "ultrafast", "-crf", "28",
         "-pix_fmt", "yuv420p",
         "-vf", vf,
-        "-c:a", "aac",
-        "-b:a", "128k",
+        "-c:a", "aac", "-b:a", "128k",
         "-t", str(duration),
         str(out_path),
     ]
@@ -229,8 +205,7 @@ def concat_clips(clip_paths: list[Path], out_path: Path):
     try:
         cmd = [
             "ffmpeg", "-y",
-            "-f", "concat",
-            "-safe", "0",
+            "-f", "concat", "-safe", "0",
             "-i", list_file,
             "-c", "copy",
             str(out_path),
@@ -243,7 +218,12 @@ def concat_clips(clip_paths: list[Path], out_path: Path):
 
 
 def add_bgm(video_path: Path, out_path: Path) -> bool:
-    """BGMを動画にミックス（ニュース系と同じ方法: amix weights=1 BGM_VOL）"""
+    """BGMを動画にミックス。
+
+    amix=duration=first のみ使用し、apadは不要。
+    first（ナレーション側）が終わった時点で出力終了するため
+    duration計算なしに正確な長さが得られる。
+    """
     bgm_files = sorted(
         glob.glob("assets/bgm/*.mp3") + glob.glob("assets/bgm/*.m4a")
     )
@@ -253,19 +233,16 @@ def add_bgm(video_path: Path, out_path: Path) -> bool:
     bgm_path = random.choice(bgm_files)
     print(f"  BGM: {Path(bgm_path).name} (vol={BGM_VOL})")
 
-    total_dur = get_audio_duration(video_path)
     cmd = [
         "ffmpeg", "-y",
         "-i", str(video_path),
         "-stream_loop", "-1", "-i", bgm_path,
         "-filter_complex",
-        f"[0:a]apad=whole_dur={total_dur:.3f}[narr];"
-        f"[narr][1:a]amix=inputs=2:duration=first:weights=1 {BGM_VOL}[aout]",
+        f"[0:a][1:a]amix=inputs=2:duration=first:weights=1 {BGM_VOL}[aout]",
         "-map", "0:v",
         "-map", "[aout]",
         "-c:v", "copy",
-        "-c:a", "aac",
-        "-b:a", "192k",
+        "-c:a", "aac", "-b:a", "192k",
         str(out_path),
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -317,7 +294,6 @@ def main():
         n = q["number"]
         print(f"  Q{n} 問題クリップ（シンキングタイム{THINK_DURATION}秒）...")
 
-        # シンキングタイムクリップ（カウントダウン表示・問題文は読まない）
         q_think_clip = clips_dir / f"{n:02d}q_think.mp4"
         make_question_silence_clip(
             SLIDES_DIR / f"{n:02d}q_question.png",
@@ -326,7 +302,6 @@ def main():
         )
         clip_paths.append(q_think_clip)
 
-        # 回答クリップ
         print(f"  Q{n} 回答クリップ...")
         a_clip = clips_dir / f"{n:02d}a.mp4"
         make_clip(


### PR DESCRIPTION
## 根本原因と修正

### 空白動画・音ずれ（最重要）
`get_audio_duration` が edge-tts MP3 の VBR duration メタデータから誤値（実5秒→100秒など）を取得し、`apad=whole_dur=105秒` で音声トラックが膨大に伸びていた。映像は正常に終了するが音声トラックだけ2分続くため白画面が発生。

**修正**: `apad=pad_dur=extra_secs` + `-shortest` に変更。duration計算が不要になり誤値の影響を完全排除。

### add_bgm 修正
`apad=whole_dur` を廃止し `amix=duration=first` のみに変更。ナレーション終端で自動終了するためduration計算不要。

### 音量
TTS に `volume="+50%"` を追加（edge-tts Communicate パラメータ）。

### フォントサイズ拡大
バナー 34→40、「この馬は誰？」44→52、clue 22→26、choice 26→30、正解ラベル 44→50、解説 26→32

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg3Bi3L51qQetSqnMxGbMa)_