### PR TITLE
refactor: make_clip を -shortest で音声自動同期に変更

### DIFF
--- a/requirements-quiz.txt
+++ b/requirements-quiz.txt
@@ -1,4 +1,3 @@
 anthropic>=0.28.0
 edge-tts>=6.1.9
 matplotlib>=3.8.0
-mutagen>=1.47.0

--- a/scripts/quiz_step2_slides.py
+++ b/scripts/quiz_step2_slides.py
@@ -93,9 +93,9 @@ def make_question_slide(q: dict, out_path: Path):
 
     # 「この馬は誰？」 + 問題番号
     ax.text(0.5, 0.858, "この馬は誰？", ha="center", va="center",
-            color=ACCENT, fontsize=52, fontweight="bold")
+            color=ACCENT, fontsize=58, fontweight="bold")
     ax.text(0.97, 0.858, f"{q['number']} / 5問", ha="right", va="center",
-            color="#8090a0", fontsize=26)
+            color="#8090a0", fontsize=28)
 
     # G1勝利歴（全件・2列レイアウト）
     clues = q["clues"]
@@ -106,7 +106,7 @@ def make_question_slide(q: dict, out_path: Path):
         zorder=2,
     ))
     ax.text(0.5, 0.81, "G1 勝利歴", ha="center", va="center",
-            color=ACCENT, fontsize=30, fontweight="bold", zorder=3)
+            color=ACCENT, fontsize=34, fontweight="bold", zorder=3)
 
     # 2列に分割
     half = (len(clues) + 1) // 2
@@ -118,11 +118,11 @@ def make_question_slide(q: dict, out_path: Path):
     for i, clue in enumerate(col_left):
         y = base_y - i * row_h
         ax.text(0.07, y, f"◆ {clue}", ha="left", va="center",
-                color=WHITE, fontsize=26, fontweight="bold", zorder=3)
+                color=WHITE, fontsize=32, fontweight="bold", zorder=3)
     for i, clue in enumerate(col_right):
         y = base_y - i * row_h
         ax.text(0.55, y, f"◆ {clue}", ha="left", va="center",
-                color=WHITE, fontsize=26, fontweight="bold", zorder=3)
+                color=WHITE, fontsize=32, fontweight="bold", zorder=3)
 
     # 4択（2×2グリッド）― choiceはクルーパネルより下に配置
     choices = q["choices"]
@@ -135,7 +135,7 @@ def make_question_slide(q: dict, out_path: Path):
         if i < len(choices):
             draw_choice_box(ax, bx, by, box_w, box_h,
                             CHOICE_LABELS[i], choices[i],
-                            CHOICE_BG, CHOICE_BORDER, fontsize=30)
+                            CHOICE_BG, CHOICE_BORDER, fontsize=36)
 
     plt.tight_layout(pad=0)
     fig.savefig(out_path, dpi=DPI, bbox_inches="tight", facecolor=BG)
@@ -161,7 +161,7 @@ def make_answer_slide(q: dict, out_path: Path):
     # 正解ラベル
     ax.text(0.5, 0.82, f"正解は  {correct_label}. {correct_name}！",
             ha="center", va="center",
-            color="#2ecc71", fontsize=50, fontweight="bold")
+            color="#2ecc71", fontsize=56, fontweight="bold")
 
     # 4択（正解=緑、不正解=暗赤色）
     box_w, box_h = 0.44, 0.11
@@ -177,7 +177,7 @@ def make_answer_slide(q: dict, out_path: Path):
                 bg, border = WRONG_BG, WRONG_BORDER
             draw_choice_box(ax, bx, by, box_w, box_h,
                             CHOICE_LABELS[i], choices[i],
-                            bg, border, fontsize=30)
+                            bg, border, fontsize=36)
 
     # 解説パネル
     ax.add_patch(mpatches.FancyBboxPatch(
@@ -187,12 +187,12 @@ def make_answer_slide(q: dict, out_path: Path):
         zorder=2,
     ))
     ax.text(0.07, 0.33, "◆ 解説", ha="left", va="center",
-            color=ACCENT, fontsize=28, fontweight="bold", zorder=3)
+            color=ACCENT, fontsize=32, fontweight="bold", zorder=3)
     ax.text(0.5, 0.20, q["display_explanation"], ha="center", va="center",
-            color=WHITE, fontsize=32, multialignment="center", zorder=3)
+            color=WHITE, fontsize=38, multialignment="center", zorder=3)
 
     ax.text(0.97, 0.03, f"{q['number']} / 5問", ha="right", va="center",
-            color="#606080", fontsize=24)
+            color="#606080", fontsize=26)
 
     plt.tight_layout(pad=0)
     fig.savefig(out_path, dpi=DPI, bbox_inches="tight", facecolor=BG)

--- a/scripts/quiz_step3_video.py
+++ b/scripts/quiz_step3_video.py
@@ -136,6 +136,9 @@ def make_clip(slide_path: Path, audio_path: Path | None, extra_secs: float, out_
             "-pix_fmt", "yuv420p",
             "-vf", scale_vf,
             "-c:a", "aac", "-b:a", "128k",
+            # edge-tts は 24kHz MP3 を生成するが、シンキングタイムクリップは
+            # 44100Hz なため concat 時に音ずれが起きる。-ar 44100 で統一する。
+            "-ar", "44100",
             "-af", f"apad=whole_dur={total_dur:.3f}",
             "-t", f"{total_dur:.3f}",
         ]

--- a/scripts/quiz_step3_video.py
+++ b/scripts/quiz_step3_video.py
@@ -6,7 +6,6 @@ import glob
 import json
 import os
 import random
-import re
 import subprocess
 import sys
 import tempfile
@@ -33,23 +32,6 @@ BGM_VOL = 0.12
 FPS = 30
 WIDTH = 1920
 HEIGHT = 1080
-
-
-def get_audio_duration(audio_path: Path) -> float:
-    """MP3の正確な再生時間を取得（VBR誤メタデータ回避）"""
-    try:
-        from mutagen.mp3 import MP3
-        return MP3(str(audio_path)).info.length
-    except Exception:
-        pass
-    result = subprocess.run(
-        ["ffmpeg", "-i", str(audio_path)], capture_output=True, text=True
-    )
-    m = re.search(r"Duration:\s*(\d+):(\d+):([\d.]+)", result.stderr)
-    if m:
-        h, mi, s = int(m.group(1)), int(m.group(2)), float(m.group(3))
-        return h * 3600 + mi * 60 + s
-    return 30.0
 
 
 def find_noto_font() -> str | None:
@@ -113,8 +95,9 @@ async def synthesize_all(quiz: dict):
 def make_clip(slide_path: Path, audio_path: Path | None, extra_secs: float, out_path: Path):
     """スライド画像 + 音声から動画クリップを生成。
 
-    mutagen で正確な音声長を計測し -t で明示的にクリップ長を指定することで、
-    edge-tts VBR MP3 の duration メタデータ誤値に依存しない。
+    -shortest で音声終端にスライドを自動同期。duration 計算不要。
+    apad=pad_dur で末尾に extra_secs 秒の余韻無音を追加する。
+    -ar 44100 でシンキングタイムクリップ（44100Hz）と統一し concat での音ずれを防ぐ。
     """
     cmd = [
         "ffmpeg", "-y",
@@ -128,19 +111,15 @@ def make_clip(slide_path: Path, audio_path: Path | None, extra_secs: float, out_
     )
 
     if audio_path and audio_path.exists():
-        audio_dur = get_audio_duration(audio_path)
-        total_dur = audio_dur + extra_secs
         cmd += ["-i", str(audio_path)]
         cmd += [
             "-c:v", "libx264", "-preset", "ultrafast", "-crf", "28",
             "-pix_fmt", "yuv420p",
             "-vf", scale_vf,
             "-c:a", "aac", "-b:a", "128k",
-            # edge-tts は 24kHz MP3 を生成するが、シンキングタイムクリップは
-            # 44100Hz なため concat 時に音ずれが起きる。-ar 44100 で統一する。
             "-ar", "44100",
-            "-af", f"apad=whole_dur={total_dur:.3f}",
-            "-t", f"{total_dur:.3f}",
+            "-af", f"apad=pad_dur={extra_secs}",
+            "-shortest",
         ]
     else:
         cmd += [


### PR DESCRIPTION
## 変更内容

duration の事前計算をやめ、ffmpeg の `-shortest` に音声同期を委ねる方式に変更。

**仕組み:**
- `-loop 1` で映像は無限ループ
- `apad=pad_dur=extra_secs` で音声末尾に余韻（無音）を追加  
- `-shortest` で「音声フィルター出力が終わったら映像も停止」→ duration 計算不要
- `-ar 44100` は維持（シンキングタイムクリップとの concat 音ずれ対策）

**削除:**
- `get_audio_duration()` 関数（不要）
- `import re`（不要）
- `requirements-quiz.txt` から `mutagen` を削除

https://claude.ai/code/session_01Dg3Bi3L51qQetSqnMxGbMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg3Bi3L51qQetSqnMxGbMa)_