### PR TITLE
fix: ステップレース結果の引用を未来レース創作と誤判定するバグを修正

### DIFF
--- a/scripts/generate_script.py
+++ b/scripts/generate_script.py
@@ -16,8 +16,8 @@ NEWS_JSON = "news.json"
 OUTPUT_DIR = "output"
 GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 PREFERRED_MODELS = [
-    "gemini-2.0-flash",
     "gemini-2.5-flash",
+    "gemini-2.0-flash",
     "gemini-2.0-flash-lite",
     "gemma-3-4b-it",
     "gemma-3-1b-it",
@@ -427,8 +427,10 @@ def main() -> None:
                 )
                 article_text = item.get("title", "") + item.get("body", item.get("summary", ""))
                 if future_race_keywords.search(article_text) and fabricated_result_pattern.search(script):
-                    print(f"[{i}]  → 未来レース記事にレース結果の創作を検出。次のキー/モデルへ切り替えます: {script[:60]}", file=sys.stderr)
-                    continue
+                    # 元記事のsummaryに同じ表現がある場合はステップレース結果の引用であり創作ではない
+                    if not fabricated_result_pattern.search(summary_text):
+                        print(f"[{i}]  → 未来レース記事にレース結果の創作を検出。次のキー/モデルへ切り替えます: {script[:60]}", file=sys.stderr)
+                        continue
                 # 馬を抽象的に表現している場合はスキップ
                 # 「ある馬」「2着となった馬」「スプリンターたち」「注目激走馬」など、馬名なしの曖昧表現を検出
                 # ただし、カタカナ5文字以上の固有名詞（≒競走馬名）がある場合は馬名あり扱いでスキップしない


### PR DESCRIPTION
## 問題

前哨戦結果をNHKマイルC展望として分析する記事（例: 「ファルコンS結果からNHKマイルCを読む」）で、Geminiが元記事を正しく引用しても「未来レース結果の創作」と誤判定し、全15キー×モデル組み合わせを消費して失敗していた。

## 原因

`generate_script.py` の未来レース検出ロジックが、元記事の `summary_text` に含まれる表現（「好位から楽に抜け出した」「レースレコードで制した」等）をGeminiが引用した場合も創作と判断していた。

## 修正内容

- `fabricated_result_pattern` がマッチしても、元記事(`summary_text`)に同じ表現があれば「引用」と判定してスキップしない
- `PREFERRED_MODELS` の順序を `gemini-2.5-flash` 優先に変更（429が多い `gemini-2.0-flash` より先に試行してクォータ消費を軽減）

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyxSvyP3kmxiatX1NPZS7A)_