### PR TITLE
chore: 名馬列伝の毎日自動投稿スケジュールを一時停止

### DIFF
--- a/.github/workflows/daily_famous_horse.yml
+++ b/.github/workflows/daily_famous_horse.yml
@@ -1,8 +1,8 @@
 name: Daily Famous Horse - 名馬列伝 毎日自動投稿
 
 on:
-  schedule:
-    - cron: '0 8 * * *'   # 17:00 JST (UTC+9 → UTC 08:00)
+  # schedule:
+  #   - cron: '0 8 * * *'   # 17:00 JST (UTC+9 → UTC 08:00)  ← 自動投稿を一時停止
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## 変更内容

`daily_famous_horse.yml` のスケジュール実行（毎日17:00 JST）をコメントアウトして自動投稿を停止。

`workflow_dispatch`（手動実行）は引き続き使用可能。

再開する場合は `schedule` のコメントを外すだけでOK。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UppvEuzcFZnGgesvDoiyDA)_