### PR TITLE
feat: 日本ダービー2026 横型動画（1280×720）を追加

### DIFF
--- a/.github/workflows/derby_landscape_prediction.yml
+++ b/.github/workflows/derby_landscape_prediction.yml
@@ -1,0 +1,103 @@
+name: 日本ダービー2026 枠順確定予想動画（横型）生成・投稿
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "テストモード（YouTubeにアップせずArtifactのみ）"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  post-derby-landscape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            ffmpeg \
+            fonts-noto-cjk \
+            libfontconfig1
+          echo "ffmpeg version: $(ffmpeg -version 2>&1 | head -1)"
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: 日本ダービー2026 枠順確定予想コンテンツを生成
+        run: python scripts/create_derby_prediction.py
+
+      - name: Generate audio（音声 + ASS字幕）
+        run: python scripts/generate_audio.py
+
+      - name: BGMをダウンロード (CC0 public domain only)
+        continue-on-error: true
+        run: |
+          mkdir -p assets/bgm
+          python scripts/download_bgm.py
+
+      - name: フォントをダウンロード
+        continue-on-error: true
+        run: |
+          mkdir -p assets/fonts
+          python scripts/download_fonts.py
+
+      - name: 背景画像を取得（Pixabay）
+        continue-on-error: true
+        env:
+          PIXABAY_API_KEY: ${{ secrets.PIXABAY_API_KEY }}
+        run: python scripts/download_horse_images.py
+
+      - name: Generate landscape video（横型 1280×720）
+        run: python scripts/landscape_video.py
+
+      - name: Upload video as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: derby-2026-landscape-video
+          path: output/landscape_video_0.mp4
+          retention-days: 7
+
+      - name: Upload to YouTube
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GOOGLE_CLIENT_ID:       ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET:   ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_REFRESH_TOKEN:   ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+          GOOGLE_CLIENT_ID_2:     ${{ secrets.GOOGLE_CLIENT_ID2 }}
+          GOOGLE_CLIENT_SECRET_2: ${{ secrets.GOOGLE_CLIENT_SECRET2 }}
+          GOOGLE_REFRESH_TOKEN_2: ${{ secrets.GOOGLE_REFRESH_TOKEN_2 }}
+          GOOGLE_CLIENT_ID_3:     ${{ secrets.GOOGLE_CLIENT_ID3 }}
+          GOOGLE_CLIENT_SECRET_3: ${{ secrets.GOOGLE_CLIENT_SECRET3 }}
+          GOOGLE_REFRESH_TOKEN_3: ${{ secrets.GOOGLE_REFRESH_TOKEN3 }}
+        run: python scripts/upload_landscape_youtube.py
+
+      - name: Commit and push
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add posted_landscape_ids.txt last_upload_result.txt output/thumbnail_*.jpg 2>/dev/null || true
+          if git diff --staged --quiet; then
+            echo "変更なし。コミットをスキップします。"
+          else
+            git commit -m "chore: 日本ダービー2026枠順確定予想動画（横型）投稿完了 [skip ci]"
+            git push origin HEAD:${{ github.ref_name }}
+          fi

--- a/scripts/create_derby_prediction.py
+++ b/scripts/create_derby_prediction.py
@@ -46,6 +46,10 @@ NEWS_ENTRY = {
     ),
     "image_url": "",
     "published_date": "2026-05-28T20:00:00+09:00",
+    # landscape_video.py / upload_landscape_youtube.py が参照するフィールド
+    "race_name": "日本ダービー",
+    "grade": "G1",
+    "horses": ["ロブチェン", "ライヒスアドラー", "リアライズシリウス", "バステール"],
     # 自動抽出されないタグを手動で追加（日本語レース名・競馬用語）
     "extra_tags": [
         "日本ダービー", "東京優駿", "ダービー2026", "枠順", "二冠",


### PR DESCRIPTION
## 変更内容

### `scripts/create_derby_prediction.py`
`landscape_video.py` / `upload_landscape_youtube.py` が参照する3フィールドを `NEWS_ENTRY` に追加：

```python
"race_name": "日本ダービー",
"grade":     "G1",
"horses":    ["ロブチェン", "ライヒスアドラー", "リアライズシリウス", "バステール"],
```

`horses` は Wikipedia → Pixabay の順で背景画像を取得する際に使用。取得できない場合は geq グラデーションにフォールバック。

### `.github/workflows/derby_landscape_prediction.yml`
横型（1280×720）動画の生成・投稿ワークフロー。

- Shorts版と**同じ脚本・音声・ASS字幕**を使用
- `landscape_video.py` で横型動画を生成
- `upload_landscape_youtube.py` で別チャンネルに投稿
- `dry_run` モード・Artifact保存（7日間）付き
- 投稿後に `posted_landscape_ids.txt` をコミット

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoE4RSPpdKmkQ6gxdRL5Ry)_