### PR TITLE
fix: Gemini API タイムアウトをキャッチしてリトライ対象に追加

### DIFF
--- a/scripts/generate_script.py
+++ b/scripts/generate_script.py
@@ -239,7 +239,11 @@ def call_gemini(api_key: str, model_name: str, prompt: str, system_prompt: str =
         if wait:
             print(f"  {wait}秒待機後にリトライ... (attempt {attempt + 1})")
             time.sleep(wait)
-        resp = requests.post(url, json=body, params={"key": api_key}, timeout=30)
+        try:
+            resp = requests.post(url, json=body, params={"key": api_key}, timeout=120)
+        except requests.exceptions.ReadTimeout:
+            print(f"  [警告] タイムアウト (attempt {attempt + 1})。リトライします。", file=sys.stderr)
+            continue
         print(f"  HTTP {resp.status_code}")
         if resp.status_code == 429:
             err = resp.json().get("error", {})


### PR DESCRIPTION
## 概要

`call_gemini` の `requests.post` で `timeout=30` が短すぎ、gemini-2.5-flash の応答を待ちきれずに `ReadTimeout` がクラッシュしていた問題を修正。

## 変更内容

- タイムアウトを `30 → 120` 秒に延長
- `ReadTimeout` を for ループ内で `try/except` キャッチし、429/503 と同様にリトライ対象に変更（最大3回: 0秒待 → 30秒待 → 60秒待）

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCcD5oCn2XSz9rapQ1yUSY)_