### PR TITLE
TTS読み上げテストを読み辞書変更時に自動実行する

### DIFF
--- a/.github/workflows/tts_reading_test.yml
+++ b/.github/workflows/tts_reading_test.yml
@@ -1,9 +1,19 @@
 name: TTS読み上げテスト
 
-# 手動実行専用。data/tts_reading_test.txt を音声合成し、
-# 読み変換の検証結果をログに、生成音声をアーティファクトに出力する。
+# data/tts_reading_test.txt を音声合成し、読み変換の検証結果をログに、
+# 生成音声をアーティファクトに出力する。手動実行のほか、読み辞書や
+# 置換ロジックが変更されたときにも回帰テストとして自動実行される。
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - data/tts_reading_test.txt
+      - data/jockeys.json
+      - data/readings.json
+      - scripts/reading_utils.py
+      - .github/workflows/tts_reading_test.yml
 
 jobs:
   tts-reading-test:


### PR DESCRIPTION
GitHub App からの workflow_dispatch が権限不足（403）で実行できないため、読み辞書・置換ロジック・テスト原稿の変更が main に push されたときにも自動実行されるようにする。このマージ自体でテストが1回走る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEiW3Rnccs3DVuDC5CVAGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEiW3Rnccs3DVuDC5CVAGL)_