### PR TITLE
TTSテストの音声出力を tts-test-output ブランチにも保存する

### DIFF
--- a/.github/workflows/tts_reading_test.yml
+++ b/.github/workflows/tts_reading_test.yml
@@ -109,3 +109,14 @@ jobs:
             output/audio_0.mp3
             output/subtitles_0.ass
           retention-days: 7
+
+      # アーティファクトをブラウザ外から取得できるよう、専用ブランチにも保存する
+      # （毎回force pushするので履歴は増えない）
+      - name: 音声を tts-test-output ブランチに保存
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch --orphan tts-test-output
+          git add -f output/audio_0.mp3 output/subtitles_0.ass
+          git commit -m "TTS読み上げテスト出力 (run ${GITHUB_RUN_ID}) [skip ci]"
+          git push -f origin tts-test-output


### PR DESCRIPTION
Actions のアーティファクトはブラウザ以外から取得しづらいため、テスト音声（audio_0.mp3・subtitles_0.ass）を専用ブランチ `tts-test-output` に force push で保存する。毎回上書きするので履歴は増えない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEiW3Rnccs3DVuDC5CVAGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEiW3Rnccs3DVuDC5CVAGL)_