### PR TITLE
TTSテストワークフローに contents:write 権限を付与

### DIFF
--- a/.github/workflows/tts_reading_test.yml
+++ b/.github/workflows/tts_reading_test.yml
@@ -19,6 +19,8 @@ jobs:
   tts-reading-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write  # tts-test-output ブランチへの push 用
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
前回の実行で `tts-test-output` ブランチへの push が 403 (Permission denied to github-actions[bot]) で失敗したため、ジョブに `permissions: contents: write` を追加する。読み変換チェックと音声生成は成功していた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEiW3Rnccs3DVuDC5CVAGL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEiW3Rnccs3DVuDC5CVAGL)_