### PR TITLE
chore: ニュース自動投稿を1日7回から5回に削減（10/12/16/18/20時）

### DIFF
--- a/.github/workflows/keiba_news.yml
+++ b/.github/workflows/keiba_news.yml
@@ -2,10 +2,11 @@ name: Keiba News YouTube Auto Post
 
 on:
   schedule:
-    # 11:00〜20:00 JST を3時間おきに4回実行（JST = UTC+9）
-    - cron: "0 2 * * *"   # 11:00 JST
+    # 12:00〜20:00 JST を2時間おきに5回実行（JST = UTC+9）
+    - cron: "0 3 * * *"   # 12:00 JST
     - cron: "0 5 * * *"   # 14:00 JST
-    - cron: "0 8 * * *"   # 17:00 JST
+    - cron: "0 7 * * *"   # 16:00 JST
+    - cron: "0 9 * * *"   # 18:00 JST
     - cron: "0 11 * * *"  # 20:00 JST
   workflow_dispatch:
 

--- a/.github/workflows/keiba_news.yml
+++ b/.github/workflows/keiba_news.yml
@@ -2,8 +2,7 @@ name: Keiba News YouTube Auto Post
 
 on:
   schedule:
-    # 8:00〜20:00 JST を3時間おきに5回実行（JST = UTC+9）
-    - cron: "0 23 * * *"  #  8:00 JST
+    # 11:00〜20:00 JST を3時間おきに4回実行（JST = UTC+9）
     - cron: "0 2 * * *"   # 11:00 JST
     - cron: "0 5 * * *"   # 14:00 JST
     - cron: "0 8 * * *"   # 17:00 JST

--- a/.github/workflows/keiba_news.yml
+++ b/.github/workflows/keiba_news.yml
@@ -2,9 +2,9 @@ name: Keiba News YouTube Auto Post
 
 on:
   schedule:
-    # 12:00〜20:00 JST を2時間おきに5回実行（JST = UTC+9）
+    # 10:00〜20:00 JST に5回実行（JST = UTC+9）
+    - cron: "0 1 * * *"   # 10:00 JST
     - cron: "0 3 * * *"   # 12:00 JST
-    - cron: "0 5 * * *"   # 14:00 JST
     - cron: "0 7 * * *"   # 16:00 JST
     - cron: "0 9 * * *"   # 18:00 JST
     - cron: "0 11 * * *"  # 20:00 JST

--- a/.github/workflows/keiba_news.yml
+++ b/.github/workflows/keiba_news.yml
@@ -2,13 +2,11 @@ name: Keiba News YouTube Auto Post
 
 on:
   schedule:
-    # 8:00〜20:00 JST を2時間おきに7回実行（JST = UTC+9）
+    # 8:00〜20:00 JST を3時間おきに5回実行（JST = UTC+9）
     - cron: "0 23 * * *"  #  8:00 JST
-    - cron: "0 1 * * *"   # 10:00 JST
-    - cron: "0 3 * * *"   # 12:00 JST
+    - cron: "0 2 * * *"   # 11:00 JST
     - cron: "0 5 * * *"   # 14:00 JST
-    - cron: "0 7 * * *"   # 16:00 JST
-    - cron: "0 9 * * *"   # 18:00 JST
+    - cron: "0 8 * * *"   # 17:00 JST
     - cron: "0 11 * * *"  # 20:00 JST
   workflow_dispatch:
 


### PR DESCRIPTION
## 変更内容

`keiba_news.yml` のcronスケジュールを変更し、ニュース動画の自動投稿回数を削減。

- **変更前**: 8:00〜20:00 JST の2時間おきに1日7回
- **変更後**: 10:00・12:00・16:00・18:00・20:00 JST の1日5回

1回あたりの投稿上限（MAX_NEWS=3）は変更なし。1日の最大投稿数は21本→15本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuvaMuKGL4r5TNPpdc5r8T

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuvaMuKGL4r5TNPpdc5r8T)_