### PR TITLE
feat: 人気ニュースを横型動画（1280×720・通常動画）で投稿する方式に変更

### DIFF
--- a/.github/workflows/keiba_popular_news.yml
+++ b/.github/workflows/keiba_popular_news.yml
@@ -105,51 +105,6 @@ jobs:
             exit $STATUS
           fi
 
-      - name: AI画像を生成
-        id: ai_images
-        if: steps.check_news.outputs.has_news == 'true'
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GEMINI_API_KEY_2: ${{ secrets.GEMINI_API_KEY_2 }}
-          GEMINI_API_KEY_3: ${{ secrets.GEMINI_API_KEY_3 }}
-          PIXABAY_API_KEY: ${{ secrets.PIXABAY_API_KEY }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          HF_TOKEN_2: ${{ secrets.HF_TOKEN_2 }}
-          HF_TOKEN_3: ${{ secrets.HF_TOKEN_3 }}
-        run: |
-          python -u scripts/generate_images.py 2>&1 | tee "$GITHUB_WORKSPACE/ai_images_log.txt"
-          exit ${PIPESTATUS[0]}
-
-      - name: AI画像ログをIssueに投稿（失敗時のみ）
-        if: failure() && steps.ai_images.conclusion == 'failure'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          python3 - <<'PYEOF'
-          import os, json, urllib.request, datetime
-          log_path = os.environ.get("GITHUB_WORKSPACE", "") + "/ai_images_log.txt"
-          try:
-              with open(log_path) as f:
-                  log = "".join(f.readlines()[:80])
-          except Exception:
-              log = "(ログなし)"
-          title = "[DEBUG] AI画像生成ログ(人気ニュース) " + datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M")
-          body = "```\n" + log + "\n```"
-          payload = json.dumps({"title": title, "body": body}).encode()
-          repo = os.environ["GH_REPO"]
-          token = os.environ["GH_TOKEN"]
-          req = urllib.request.Request(
-              f"https://api.github.com/repos/{repo}/issues",
-              data=payload,
-              headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
-              method="POST",
-          )
-          with urllib.request.urlopen(req) as resp:
-              data = json.loads(resp.read())
-              print(f"Issue作成: {data.get('html_url')}")
-          PYEOF
-
       - name: Check if scripts exist
         id: check_scripts
         if: steps.check_news.outputs.has_news == 'true'
@@ -177,18 +132,8 @@ jobs:
           mkdir -p assets/bgm
           python scripts/download_bgm.py 2>&1 | tee /tmp/download_bgm.log
 
-      - name: フォントをダウンロード (太ゴシック・デザイン系)
-        if: steps.check_scripts.outputs.has_scripts == 'true'
-        continue-on-error: true
-        run: |
-          mkdir -p assets/fonts
-          python scripts/download_fonts.py
-
-      - name: Generate video
-        if: steps.check_scripts.outputs.has_scripts == 'true'
-        run: python scripts/generate_video.py
-
-      - name: Upload to YouTube
+      # 人気ニュースは横型（1280×720）の通常動画として生成・投稿する
+      - name: Generate and upload landscape video
         if: steps.check_scripts.outputs.has_scripts == 'true'
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
@@ -200,7 +145,7 @@ jobs:
           GOOGLE_CLIENT_ID_3: ${{ secrets.GOOGLE_CLIENT_ID3 }}
           GOOGLE_CLIENT_SECRET_3: ${{ secrets.GOOGLE_CLIENT_SECRET3 }}
           GOOGLE_REFRESH_TOKEN_3: ${{ secrets.GOOGLE_REFRESH_TOKEN3 }}
-        run: python scripts/upload_youtube.py
+        run: python scripts/popular_landscape_post.py
 
       - name: Upload video sources as artifact
         if: always() && steps.check_scripts.outputs.has_scripts == 'true'
@@ -208,7 +153,7 @@ jobs:
         with:
           name: popular-news-videos-${{ github.run_id }}
           path: |
-            output/upload_results.json
+            last_upload_result.txt
             output/script_*.txt
             output/audio_*.mp3
             output/subtitles_*.ass

--- a/scripts/popular_landscape_post.py
+++ b/scripts/popular_landscape_post.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""人気ニュース（news.json）を横型動画（1280×720・通常動画）として生成・投稿する。
+
+generate_audio.py が output/script_N.txt / audio_N.mp3 / subtitles_N.ass を
+生成済みであることを前提に、landscape_video.py のパイプラインでネイティブな
+横型動画を生成し、#Shortsなしの通常動画としてアップロードする。
+
+投稿済みIDは既存の posted_ids.txt に追記し、縦型ニュースパイプライン
+（keiba_news.yml）との重複投稿を防ぐ。
+"""
+
+import datetime
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import landscape_video  # 横型動画のネイティブ生成パイプラインを再利用
+import upload_landscape_youtube as uploader  # 認証・アップロード・サムネイル処理を再利用
+
+from googleapiclient.discovery import build
+
+JST = datetime.timezone(datetime.timedelta(hours=9))
+NEWS_JSON = "news.json"
+OUTPUT_DIR = "output"
+POSTED_IDS_FILE = "posted_ids.txt"
+RESULT_FILE = "last_upload_result.txt"
+
+
+def append_posted_id(entry_id: str) -> None:
+    path = Path(POSTED_IDS_FILE)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    if entry_id in existing.splitlines():
+        return
+    with path.open("a", encoding="utf-8") as f:
+        f.write(entry_id + "\n")
+    print(f"投稿済みIDを {POSTED_IDS_FILE} に追記: {entry_id}")
+
+
+def build_title(item: dict) -> str:
+    now = datetime.datetime.now(JST)
+    date_str = f"{now.month}月{now.day}日"
+    return f"【話題】{date_str} {item['title']}"[:100]
+
+
+def build_description(item: dict) -> str:
+    views = item.get("views", 0)
+    lead = "いま最も読まれている競馬ニュースをお届けします。"
+    if views:
+        lead = f"いま最も読まれている競馬ニュースをお届けします（netkeibaアクセスランキングより）。"
+    return (
+        f"{lead}\n"
+        f"{item['title']}\n\n"
+        f"#競馬 #競馬ニュース #JRA #keiba #競馬速報"
+    )
+
+
+def extract_frame_thumbnail(video_path: str, idx: int) -> str:
+    """フォールバック: 横型動画の先頭フレームを抽出してサムネイルにする（リサイズ禁止）。"""
+    thumb_path = f"{OUTPUT_DIR}/thumbnail_{idx}.jpg"
+    result = subprocess.run([
+        "ffmpeg", "-y", "-ss", "0.5", "-i", video_path,
+        "-vframes", "1", "-q:v", "2", thumb_path,
+    ], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  [警告] サムネイル抽出失敗: {result.stderr[-200:]}", file=sys.stderr)
+    return thumb_path
+
+
+def write_result(lines: list[str]) -> None:
+    header = [f"date: {datetime.datetime.utcnow().isoformat()}Z", "type: popular_news_landscape"]
+    Path(RESULT_FILE).write_text("\n".join(header + lines) + "\n", encoding="utf-8")
+    print("\n".join(header + lines))
+
+
+def main() -> None:
+    print("=== 人気ニュース 横型動画投稿 ===")
+    if not Path(NEWS_JSON).exists():
+        print(f"[エラー] {NEWS_JSON} が見つかりません。", file=sys.stderr)
+        sys.exit(1)
+    news_items: list[dict] = json.loads(Path(NEWS_JSON).read_text(encoding="utf-8"))
+    if not news_items:
+        print("news.json が空です。スキップします。")
+        return
+
+    Path(OUTPUT_DIR).mkdir(exist_ok=True)
+
+    all_creds, load_log = uploader.load_all_credentials()
+    cred_idx = 0
+    youtube = build("youtube", "v3", credentials=all_creds[cred_idx])
+
+    font = landscape_video.find_font()
+    result_lines: list[str] = []
+
+    for idx, item in enumerate(news_items):
+        if not Path(f"{OUTPUT_DIR}/script_{idx}.txt").exists():
+            print(f"[{idx}] 脚本なし（生成スキップ記事）。スキップします。")
+            continue
+
+        # リポジトリにコミット済みの古いサムネイルが残っていると
+        # landscape_video.generate_video が生成をスキップしてしまうため先に消す
+        Path(f"{OUTPUT_DIR}/thumbnail_{idx}.jpg").unlink(missing_ok=True)
+
+        print(f"\n--- [{idx}] {item['title'][:50]} (views={item.get('views', 0):,}) ---")
+        bg_imgs = landscape_video.fetch_images(4, horse_names=item.get("horses"))
+        video_path = landscape_video.generate_video(idx, item, font, bg_imgs)
+
+        title = build_title(item)
+        description = build_description(item)
+        extra_tags = ["競馬ニュース", "JRA", "競馬速報", "ニュース"]
+
+        video_id = None
+        while video_id is None:
+            result = uploader.upload_video(youtube, title, description,
+                                           video_path, extra_tags=extra_tags)
+            if result == "CHANNEL_LIMIT":
+                write_result(load_log + result_lines + [f"CHANNEL_LIMIT title={title[:50]}"])
+                sys.exit(1)
+            elif result is None:
+                cred_idx += 1
+                if cred_idx < len(all_creds):
+                    print(f"  プロジェクト {cred_idx + 1} に切り替えてリトライ...")
+                    youtube = build("youtube", "v3", credentials=all_creds[cred_idx])
+                else:
+                    print("[警告] 全プロジェクトのAPIクォータが超過しました。", file=sys.stderr)
+                    write_result(load_log + result_lines + [f"QUOTA_EXCEEDED title={title[:50]}"])
+                    sys.exit(1)
+            else:
+                video_id = result
+
+        try:
+            gen_thumb = f"{OUTPUT_DIR}/thumbnail_{idx}.jpg"
+            thumb = gen_thumb if Path(gen_thumb).exists() else extract_frame_thumbnail(video_path, idx)
+            uploader.upload_thumbnail(youtube, video_id, thumb)
+        except Exception as e:
+            print(f"  [警告] サムネイル処理失敗: {e}", file=sys.stderr)
+
+        append_posted_id(item["id"])
+        result_lines.append(
+            f"OK project={cred_idx+1} video_id={video_id} views={item.get('views', 0)} title={title[:60]}"
+        )
+
+    if not result_lines:
+        result_lines.append("result: no_uploads")
+    write_result(load_log + result_lines)
+    print("\n=== 完了 ===")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

人気ニュースパイプライン（#1859）の動画形式を縦型Shortsから**横型（1280×720）の通常動画**に変更する。

「本日の人気No.1動画」の横型再投稿（`daily_top_video.py`）で実績のある `landscape_video.py` のネイティブ生成パイプラインを再利用する。

## 変更内容

### `scripts/popular_landscape_post.py`（新規）
- `news.json` の各記事について、`generate_audio.py` が生成済みの脚本・音声・ASS字幕から横型動画をネイティブ生成
- タイトルは「【話題】M月D日 記事タイトル」形式、#Shortsなしの通常動画として投稿
- 投稿成功後に既存の `posted_ids.txt` へ記事IDを追記（縦型ニュースパイプラインとの重複投稿防止を維持）
- クォータ超過時の認証プロジェクト切り替え・サムネイル設定・`last_upload_result.txt` 出力は `daily_top_video.py` と同じ方式

### `.github/workflows/keiba_popular_news.yml`
- 「AI画像生成」「縦型動画生成」「Shorts投稿」ステップを「横型生成＋投稿」の1ステップに置き換え
  - 横型パイプラインは背景画像を自前で取得するため、AI画像生成（Gemini/HF/Pixabay）が不要になりAPIクォータ消費も減る
- アーティファクトには `last_upload_result.txt` を含めるよう変更

スケジュール（8:00 / 21:00 JST、各1本）と人気ニュース取得ロジックは変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iayYNEiHAii9RYT9zyTj3

---
_Generated by [Claude Code](https://claude.ai/code/session_011iayYNEiHAii9RYT9zyTj3)_